### PR TITLE
Add citation files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@ LICENSE.md
 README.Rmd
 ^LICENSE\.md$
 ^\.github$
+^CITATION\.cff$

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,48 @@
+# -----------------------------------------------------------
+# CITATION file created with {cffr} R package, v0.4.1
+# See also: https://docs.ropensci.org/cffr/
+# -----------------------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "volcalc" in publications use:'
+type: software
+license: MIT
+title: 'volcalc: Calculate Volatility of Chemical Compounds'
+version: 1.0.0
+abstract: Use this package to calculate estimated volatility values for individual
+  compounds of interest or for all compounds in a pathway. Calculation uses the SIMPOL
+  method (Prankow and Asher, 2008), and is only currently applicable to compounds
+  and pathways in KEGG.
+authors:
+- family-names: Riemer
+  given-names: Kristina
+  email: kristinariemer@email.arizona.edu
+  orcid: https://orcid.org/0000-0003-3802-3331
+preferred-citation:
+  type: article
+  title: Automating methods for estimating metabolite volatility
+  authors:
+  - family-names: Meredith
+    given-names: LK
+  - family-names: Riemer
+    given-names: Kristina
+  - family-names: Geffre
+    given-names: P
+  - family-names: Honeker
+    given-names: L
+  - family-names: Krechmer
+    given-names: J
+  - family-names: Graves
+    given-names: K
+  - family-names: Tfaily
+    given-names: M
+  - family-names: Ledford
+    given-names: SK
+  year: in prep
+  journal: TBD
+date-released: '2023-06-06'
+contact:
+- family-names: Riemer
+  given-names: Kristina
+  email: kristinariemer@email.arizona.edu
+  orcid: https://orcid.org/0000-0003-3802-3331

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,27 @@
+c(
+  bibentry(
+    bibtype = "Manual",
+    title = "volcalc: Calculate Volatility of Chemical Compounds",
+    author = person("Kristina", "Riemer", comment = c(ORCID = "0000-0003-3802-3331")),
+    year = "2023",
+    note = "R package version 1.0.0",
+    header = "To cite volcalc in publications please use:" 
+  ),
+  bibentry(
+    bibtype = "Article",
+    title = "Automating methods for estimating metabolite volatility",
+    author = c(
+      person("LK", "Meredith"),
+      person("Kristina", "Riemer"),
+      person("P", "Geffre"),
+      person("L", "Honeker"),
+      person("J", "Krechmer"),
+      person("K", "Graves"),
+      person("M", "Tfaily"),
+      person("SK", "Ledford")
+    ),
+    year = "in prep",
+    journal = "TBD",
+    header = "Please also cite the related manuscript:"
+  )
+)


### PR DESCRIPTION
Closes #18.  
- Adds inst/CITATION so that `citation("volcalc")` shows both citation for package and for in-prep manuscript. 
- Used `cffr` package to add CITATION.cffr, which is parsed by GitHub and Zenodo.  
-  Added "git hook" with `cffr::cff_git_hook_install()` to remind you to update one citation file if you make changes in the other or in DESCRIPTION

I'd like to add the target journal for the in-prep manuscript before merging this, if possible (or maybe the citation should only  include the package for now?)