### PR TITLE
Install openbabel on other runners in GitHub actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
           #disabled until I can figure out how to install openbabel
           # - {os: windows-latest, r: 'release'} 
           # - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          # - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
           # - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
@@ -40,10 +40,14 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-      - name: Setup system dependencies
+      - name: macOS openbabel
         if: matrix.config.os == 'macos-latest'
         run: |
           brew install open-babel
+      - name: ubuntu openbabel
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          apt install openbabel
       
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,6 +48,7 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           sudo apt-get install libopenbabel-dev
+          sudo ln -s /usr/include/eigen3/Eigen /usr/include/Eigen
       
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: ubuntu openbabel
         if: matrix.config.os == 'ubuntu-latest'
         run: |
-          apt-get install openbabel
+          sudo apt-get install openbabel
       
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,7 +47,6 @@ jobs:
       - name: ubuntu openbabel
         if: matrix.config.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install openbabel
           sudo apt-get install libopenbabel-dev
       
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,8 +46,9 @@ jobs:
           brew install open-babel
       - name: ubuntu openbabel
         if: matrix.config.os == 'ubuntu-latest'
+        uses: s-weigand/setup-conda
         run: |
-          sudo apt-get install libopenbabel7
+          conda install -c conda-forge openbabel
       
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,7 +46,7 @@ jobs:
           brew install open-babel
       - name: ubuntu openbabel
         if: matrix.config.os == 'ubuntu-latest'
-        uses: s-weigand/setup-conda
+        uses: s-weigand/setup-conda@v1
       - if: matrix.config.os == 'ubuntu-latest'
         run: |
           conda install -c conda-forge openbabel

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,11 +20,11 @@ jobs:
         config:
           - {os: macos-latest,   r: 'release'}
           - {os: macos-latest,   r: 'devel'}
-          #disabled until I can figure out how to install openbabel
-          # - {os: windows-latest, r: 'release'} 
-          # - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: macos-latest,   r: 'oldrel-1'}
           - {os: ubuntu-latest,   r: 'release'}
-          # - {os: ubuntu-latest,   r: 'oldrel-1'}
+          #disabled until I can figure out how to install openbabel
+          - {os: windows-latest, r: 'release'}
+
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,7 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         run: |
           sudo apt-get install libopenbabel-dev
-          sudo ln -s /usr/include/eigen3/Eigen /usr/include/Eigen
+          sudo apt-get install libeigen3-dev
       
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: ubuntu openbabel
         if: matrix.config.os == 'ubuntu-latest'
         uses: s-weigand/setup-conda
+      - if: matrix.config.os == 'ubuntu-latest'
         run: |
           conda install -c conda-forge openbabel
       

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: ubuntu openbabel
         if: matrix.config.os == 'ubuntu-latest'
         run: |
-          apt install openbabel
+          apt-get install openbabel
       
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: ubuntu openbabel
         if: matrix.config.os == 'ubuntu-latest'
         run: |
-          sudo apt-get install openbabel
+          sudo apt-get install libopenbabel7
       
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,10 +46,9 @@ jobs:
           brew install open-babel
       - name: ubuntu openbabel
         if: matrix.config.os == 'ubuntu-latest'
-        uses: s-weigand/setup-conda@v1
-      - if: matrix.config.os == 'ubuntu-latest'
         run: |
-          conda install -c conda-forge openbabel
+          sudo apt-get install openbabel
+          sudo apt-get install libopenbabel-dev
       
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,7 +68,9 @@ sudo apt-get install libopenbabel-dev
 sudo apt-get install libeigen3-dev
 ```
 
-For other installation options see the [OpenBabel documentation](https://openbabel.org/docs/dev/Installation/install.html).
+For windows, `OpenBabel` is included in the `ChemmineOB` binary and does not need to be installed separately.
+
+For other installation options see the [OpenBabel documentation](https://openbabel.org/docs/dev/Installation/install.html) and `ChemmineOB` [install guide](https://github.com/girke-lab/ChemmineOB/blob/master/INSTALL)
 
 ### Loading package
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -61,6 +61,13 @@ For macOS, this can be installed via homebrew by running the following shell com
 brew install open-babel
 ```
 
+For ubuntu linux:
+
+``` bash
+sudo apt-get install libopenbabel-dev
+sudo apt-get install libeigen3-dev
+```
+
 For other installation options see the [OpenBabel documentation](https://openbabel.org/docs/dev/Installation/install.html).
 
 ### Loading package

--- a/README.md
+++ b/README.md
@@ -67,8 +67,13 @@ sudo apt-get install libopenbabel-dev
 sudo apt-get install libeigen3-dev
 ```
 
+For windows, `OpenBabel` is included in the `ChemmineOB` binary and does
+not need to be installed separately.
+
 For other installation options see the [OpenBabel
-documentation](https://openbabel.org/docs/dev/Installation/install.html).
+documentation](https://openbabel.org/docs/dev/Installation/install.html)
+and `ChemmineOB` [install
+guide](https://github.com/girke-lab/ChemmineOB/blob/master/INSTALL)
 
 ### Loading package
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ be installed via homebrew by running the following shell command:
 brew install open-babel
 ```
 
+For ubuntu linux:
+
+``` bash
+sudo apt-get install libopenbabel-dev
+sudo apt-get install libeigen3-dev
+```
+
 For other installation options see the [OpenBabel
 documentation](https://openbabel.org/docs/dev/Installation/install.html).
 


### PR DESCRIPTION
`sudo apt-get install openable` works on ubuntu, but then ChemmineOB can't find openbable, so it's not installing into the expected location.  Interestingly, this works fine on a docker container, just not on GitHub actions.

According to the install instructions for ChemmineOB

>If the OpenBabel include and/or library files are not in one of the default
search paths (e.g., /usr/lib,/usr/include, /usr/local/lib,/usr/local/include), then you must set the
following environment variables before installing the ChemmineOB package:
>
>OPEN_BABEL_INCDIR = path to header files
>OPEN_BABEL_LIBDIR = path to shared (.so) library file