### PR TITLE
Readme updates

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@ README.Rmd
 ^LICENSE\.md$
 ^\.github$
 ^CITATION\.cff$
+^CODE_OF_CONDUCT\.md$

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at kristinariemer@arizona.edu. 
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: volcalc
 Title: Calculate Volatility of Chemical Compounds
 Version: 1.0.0.9000
 Authors@R: c(
-    person("Kristina", "Riemer", , "kristinariemer@email.arizona.edu", role = c("aut", "cre", "cph"),
+    person("Kristina", "Riemer", , "kristinariemer@arizona.edu", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-3802-3331")),
     person("Eric R.", "Scott", role = "ctb",
            comment = c(ORCID = "0000-0002-7430-7879"))

--- a/R/dummy.R
+++ b/R/dummy.R
@@ -1,4 +1,0 @@
-#This only exists to silence a R CMD check note about ChemmineOB being in Imports but no functions being used in volcalc directly.
-dummy <- function() {
-  ChemmineOB::prop_OB
-}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,1 +1,6 @@
 `%+%` <- function(x, y)  mapply(sum, x, y, MoreArgs = list(na.rm = TRUE))
+
+#This only exists to silence a R CMD check note about ChemmineOB being in Imports but no functions being used in volcalc directly.
+zzz <- function() {
+  ChemmineOB::prop_OB
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,24 +46,26 @@ To see an example of how to use `volcalc`, run the script `example_volcalc_usage
 You can install `volcalc` from GitHub with
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("Meredith-Lab/volcalc")
+# install.packages("pak")
+pak::pkg_install("Meredith-Lab/volcalc")
 ```
 
 Or from r-universe with
 
 ``` r
-install.packages('volcalc', repos = c('https://cct-datascience.r-universe.dev', 'https://cloud.r-project.org'))
+options(repos = c('https://cct-datascience.r-universe.dev', 'https://cloud.r-project.org'))
+pak::pkg_install('volcalc')
 ```
 
-Installation of `volcalc` requires the system library [OpenBabel](https://openbabel.org/) (it's a requirement of the `ChemmineOB` package, which `volcalc` depends on).
-For macOS, this can be installed via homebrew by running the following shell command:
+Installation of `volcalc` requires the system libraries [OpenBabel](https://openbabel.org/) and Eigen3 (requirements of the `ChemmineOB` package, which `volcalc` depends on). `pak` will take care of the installation of these libraries for you on some systems, but you may need to install them manually.
+
+For macOS, they can be installed via homebrew by running the following shell command:
 
 ``` bash
 brew install open-babel
 ```
 
-For ubuntu linux:
+For Ubuntu Linux:
 
 ``` bash
 sudo apt-get install libopenbabel-dev

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,12 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-The goal of volcalc is to automate calculating estimates of volatility for chemical compounds.
+The goal of `volcalc` is to automate calculating estimates of volatility for chemical compounds.
+
+**`volcalc` is a work in progress---use at your own risk!**
+
+It is still in a stage of development likely to introduce many breaking changes.  For a bit of a road map of where development is headed, see our [proposal](https://cct-datascience.github.io/volcalc-isc-proposal/) for the R Consortium grant.
+
 
 Volatility can be estimated for most chemical compounds that are in the [KEGG](https://www.genome.jp/kegg/) database, using just the [KEGG unique identifier](https://www.genome.jp/kegg/compound/) for the compound of interest.
 Alternatively, volatility can be estimated for multiple compounds that are in a [KEGG pathway](https://www.genome.jp/kegg/pathway.html).

--- a/README.Rmd
+++ b/README.Rmd
@@ -230,6 +230,10 @@ print(example_pathway_vol[1,])
 | Thiol              | N          | SMARTS              | -2.23       | Same as hydroxyl |
 | Carbothioester     | N          | SMARTS              | -1.20       | Same as ester    |
 
+## Code of Conduct
+
+Please note that the volcalc project is released with a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.
+
 ## How to contribute
 
 We appreciate many kinds of feedback and contributions to this R package.

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,6 +19,7 @@ knitr::opts_chunk$set(
 
 [![R-CMD-check](https://github.com/Meredith-Lab/volcalc/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Meredith-Lab/volcalc/actions/workflows/R-CMD-check.yaml)
 [![latest-DOI](https://zenodo.org/badge/425022983.svg)](https://zenodo.org/badge/latestdoi/425022983)
+[![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 
 <!-- badges: end -->
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -97,7 +97,8 @@ The KEGG compound identifier for the compound, as found on [the compound's KEGG 
 #### Single function approach
 
 ```{r}
-calc_vol(compound_id = "C16181")
+out_path <- tempdir()
+calc_vol(compound_id = "C16181", path = out_path)
 ```
 
 This returns a dataframe with columns specifying general info about the compound, and the compound's calculated volatility and corresponding volatility category.
@@ -116,9 +117,13 @@ This breaks the steps done by `calc_vol` into three parts: 1) download the compo
 This calculation uses the SIMPOL approach[^1].
 
 ```{r}
-save_compound_mol(compound_id = "C16181")
-example_compound_fx_groups <- get_fx_groups(compound_id = "C16181")
-example_compound_vol <- calc_vol(compound_id = "C16181", fx_groups_df = example_compound_fx_groups)
+save_compound_mol(compound_id = "C16181", path = out_path)
+example_compound_fx_groups <-
+  get_fx_groups(compound_id = "C16181", path = out_path)
+example_compound_vol <-
+  calc_vol(compound_id = "C16181",
+           fx_groups_df = example_compound_fx_groups,
+           path = out_path)
 print(example_compound_vol$volatility)
 ```
 
@@ -133,7 +138,7 @@ See function documentation for details.
 A dataframe with volatility estimates for all compounds in a chosen pathway can be returned as below.
 
 ```{r}
-example_pathway_vol <- calc_pathway_vol("map00361")
+example_pathway_vol <- calc_pathway_vol("map00361", path = out_path)
 print(example_pathway_vol[1,])
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 [![Project Status: WIP – Initial development is in progress, but there
 has not yet been a stable, usable release suitable for the
 public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
-
+[![Codecov test
+coverage](https://codecov.io/gh/Meredith-Lab/volcalc/branch/master/graph/badge.svg)](https://app.codecov.io/gh/Meredith-Lab/volcalc?branch=master)
 <!-- badges: end -->
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -45,26 +45,31 @@ To see an example of how to use `volcalc`, run the script
 You can install `volcalc` from GitHub with
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("Meredith-Lab/volcalc")
+# install.packages("pak")
+pak::pkg_install("Meredith-Lab/volcalc")
 ```
 
 Or from r-universe with
 
 ``` r
-install.packages('volcalc', repos = c('https://cct-datascience.r-universe.dev', 'https://cloud.r-project.org'))
+options(repos = c('https://cct-datascience.r-universe.dev', 'https://cloud.r-project.org'))
+pak::pkg_install('volcalc')
 ```
 
-Installation of `volcalc` requires the system library
-[OpenBabel](https://openbabel.org/) (it’s a requirement of the
-`ChemmineOB` package, which `volcalc` depends on). For macOS, this can
-be installed via homebrew by running the following shell command:
+Installation of `volcalc` requires the system libraries
+[OpenBabel](https://openbabel.org/) and Eigen3 (requirements of the
+`ChemmineOB` package, which `volcalc` depends on). `pak` will take care
+of the installation of these libraries for you on some systems, but you
+may need to install them manually.
+
+For macOS, they can be installed via homebrew by running the following
+shell command:
 
 ``` bash
 brew install open-babel
 ```
 
-For ubuntu linux:
+For Ubuntu Linux:
 
 ``` bash
 sudo apt-get install libopenbabel-dev
@@ -85,7 +90,6 @@ Use the package with:
 
 ``` r
 library(volcalc)
-#> Warning: package 'volcalc' was built under R version 4.2.3
 ```
 
 ## Single compound usage

--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostat
 
 ## Overview
 
-The goal of volcalc is to automate calculating estimates of volatility
+The goal of `volcalc` is to automate calculating estimates of volatility
 for chemical compounds.
+
+**`volcalc` is a work in progress—use at your own risk!**
+
+It is still in a stage of development likely to introduce many breaking
+changes. For a bit of a road map of where development is headed, see our
+[proposal](https://cct-datascience.github.io/volcalc-isc-proposal/) for
+the R Consortium grant.
 
 Volatility can be estimated for most chemical compounds that are in the
 [KEGG](https://www.genome.jp/kegg/) database, using just the [KEGG

--- a/README.md
+++ b/README.md
@@ -263,6 +263,13 @@ print(example_pathway_vol[1,])
 | Thiol              | N          | SMARTS              | -2.23       | Same as hydroxyl |
 | Carbothioester     | N          | SMARTS              | -1.20       | Same as ester    |
 
+## Code of Conduct
+
+Please note that the volcalc project is released with a [Contributor
+Code of
+Conduct](https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html).
+By contributing to this project, you agree to abide by its terms.
+
 ## How to contribute
 
 We appreciate many kinds of feedback and contributions to this R

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 [![R-CMD-check](https://github.com/Meredith-Lab/volcalc/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Meredith-Lab/volcalc/actions/workflows/R-CMD-check.yaml)
 [![latest-DOI](https://zenodo.org/badge/425022983.svg)](https://zenodo.org/badge/latestdoi/425022983)
+[![Project Status: WIP – Initial development is in progress, but there
+has not yet been a stable, usable release suitable for the
+public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ KEGG page](https://www.genome.jp/dbget-bin/www_bget?C16181), is
 #### Single function approach
 
 ``` r
-calc_vol(compound_id = "C16181")
+out_path <- tempdir()
+calc_vol(compound_id = "C16181", path = out_path)
 #>      pathway compound  formula                                   name
 #> CMP1      NA   C16181 C6H7Cl5O beta-2,3,4,5,6-Pentachlorocyclohexanol
 #>      volatility category
@@ -144,9 +145,13 @@ functional groups, and 3) estimate volatility. This calculation uses the
 SIMPOL approach[^1].
 
 ``` r
-save_compound_mol(compound_id = "C16181")
-example_compound_fx_groups <- get_fx_groups(compound_id = "C16181")
-example_compound_vol <- calc_vol(compound_id = "C16181", fx_groups_df = example_compound_fx_groups)
+save_compound_mol(compound_id = "C16181", path = out_path)
+example_compound_fx_groups <-
+  get_fx_groups(compound_id = "C16181", path = out_path)
+example_compound_vol <-
+  calc_vol(compound_id = "C16181",
+           fx_groups_df = example_compound_fx_groups,
+           path = out_path)
 print(example_compound_vol$volatility)
 #> [1] 6.975571
 ```
@@ -163,7 +168,7 @@ A dataframe with volatility estimates for all compounds in a chosen
 pathway can be returned as below.
 
 ``` r
-example_pathway_vol <- calc_pathway_vol("map00361")
+example_pathway_vol <- calc_pathway_vol("map00361", path = out_path)
 print(example_pathway_vol[1,])
 #>       pathway compound formula name volatility category
 #> CMP1 map00361   C00011     CO2 CO2;   7.914336     high


### PR DESCRIPTION
- Adds a WIP repo status badge (#28)
- Changes install instructions to use `pak`.  This is because `pak` will eventually be able to automatically detect the necessary system dependencies for OpenBabel and install them (currently doesn't work for Bioconductor packages, and currently only works on Linux, so not super helpful right now, but will be potentially very helpful in the future)
- Adds link to our proposal as a road map for those interested in following development of `volcalc` (#29)
- Uses `tempdir()` in the examples
- Adds a code of conduct