### PR TITLE
Fix inconsistent value for temperature

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: 'To cite package "volcalc" in publications use:'
 type: software
 license: MIT
 title: 'volcalc: Calculate Volatility of Chemical Compounds'
-version: 1.0.0
+version: 1.0.1
 abstract: Use this package to calculate estimated volatility values for individual
   compounds of interest or for all compounds in a pathway. Calculation uses the SIMPOL
   method (Prankow and Asher, 2008), and is only currently applicable to compounds

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: volcalc
 Title: Calculate Volatility of Chemical Compounds
-Version: 1.0.0.9000
+Version: 1.0.1
 Authors@R: c(
     person("Kristina", "Riemer", , "kristinariemer@arizona.edu", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-3802-3331")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# volcalc (development version)
+# volcalc 1.0.1
 
 * Minor change in calculation in `calc_vol()`---use 293.15K for temperature (instead of 293K) to match the temperature used in Pankow & Asher (2008)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # volcalc (development version)
 
+* Minor change in calculation in `calc_vol()`---use 293.15K for temperature (instead of 293K) to match the temperature used in Pankow & Asher (2008)
+
 # volcalc 1.0.0
 
 * Initial release of `volcalc`.  This is the version of the code used in an in-prep manuscript.  Version 2.0.0 will include **breaking changes**

--- a/R/calc_vol.R
+++ b/R/calc_vol.R
@@ -64,7 +64,7 @@ calc_vol <-
     # mass is converted from grams to micrograms
     # 0.0000821 is universal gas constant
     # 293 is temperature in Kelvins
-    dplyr::mutate(log_alpha = log((1000000*mass)/(0.0000821*293), base = 10),
+    dplyr::mutate(log_alpha = log((1000000*mass)/(0.0000821*293.15), base = 10),
            # multiplier for each functional group is volatility contribution
            log_Sum =
              (-0.438  * carbons) %+%

--- a/README.Rmd
+++ b/README.Rmd
@@ -65,7 +65,7 @@ pak::pkg_install('volcalc')
 You can install the 'legacy' version used in our in-prep publication with
 
 ``` r
-pak::pkg_install("Meredith-Lab/volcalc@v1.0.0")
+pak::pkg_install("Meredith-Lab/volcalc@v1.0.1")
 ```
 
 Installation of `volcalc` requires the system libraries [OpenBabel](https://openbabel.org/) and Eigen3 (requirements of the `ChemmineOB` package, which `volcalc` depends on). `pak` will take care of the installation of these libraries for you on some systems, but you may need to install them manually.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can install the ‘legacy’ version used in our in-prep publication
 with
 
 ``` r
-pak::pkg_install("Meredith-Lab/volcalc@v1.0.0")
+pak::pkg_install("Meredith-Lab/volcalc@v1.0.1")
 ```
 
 Installation of `volcalc` requires the system libraries
@@ -123,7 +123,7 @@ calc_vol(compound_id = "C16181", path = out_path)
 #>      pathway compound  formula                                   name
 #> CMP1      NA   C16181 C6H7Cl5O beta-2,3,4,5,6-Pentachlorocyclohexanol
 #>      volatility category
-#> CMP1   6.975571     high
+#> CMP1   6.975349     high
 ```
 
 This returns a dataframe with columns specifying general info about the
@@ -161,7 +161,7 @@ example_compound_vol <-
            fx_groups_df = example_compound_fx_groups,
            path = out_path)
 print(example_compound_vol$volatility)
-#> [1] 6.975571
+#> [1] 6.975349
 ```
 
 This example compound has a volatility around 7. It is in the high
@@ -179,7 +179,7 @@ pathway can be returned as below.
 example_pathway_vol <- calc_pathway_vol("map00361", path = out_path)
 print(example_pathway_vol[1,])
 #>       pathway compound formula name volatility category
-#> CMP1 map00361   C00011     CO2 CO2;   7.914336     high
+#> CMP1 map00361   C00011     CO2 CO2;   7.914113     high
 ```
 
 ## Dataframe columns

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -4,7 +4,7 @@ c(
     title = "volcalc: Calculate Volatility of Chemical Compounds",
     author = person("Kristina", "Riemer", comment = c(ORCID = "0000-0003-3802-3331")),
     year = "2023",
-    note = "R package version 1.0.0",
+    note = "R package version 1.0.1",
     doi = "10.5281/zenodo.8015155",
     header = "To cite volcalc in publications please use:" 
   ),

--- a/tests/testthat/test-calc_vol.R
+++ b/tests/testthat/test-calc_vol.R
@@ -1,12 +1,12 @@
 test_that("volatility estimate is correct for example compound for entire workflow", {
   ex_vol_df <- calc_vol(compound_id = "C16181", path = "data", redownload = FALSE)
-  expect_equal(round(ex_vol_df$volatility, 6), 6.975571)
+  expect_equal(round(ex_vol_df$volatility, 6), 6.975349)
 })
 
 test_that("volatility estimate is correct for example compound with pathway for entire workflow", {
   ex_vol_df <- calc_vol(compound_id = "C16181", pathway_id = "map00361",
                         path = "data", redownload = FALSE)
-  expect_equal(round(ex_vol_df$volatility, 6), 6.975571)
+  expect_equal(round(ex_vol_df$volatility, 6), 6.975349)
 })
 
 test_that("volatility estimate is correct for example compound from functional groups dataframe", {
@@ -15,7 +15,7 @@ test_that("volatility estimate is correct for example compound from functional g
   ex_vol_df <- calc_vol(compound_id = "C16181", pathway_id = "map00361",
                         path = "data", redownload = FALSE,
                         get_groups = FALSE, fx_groups_df = ex_fx_df)
-  expect_equal(round(ex_vol_df$volatility, 6), 6.975571)
+  expect_equal(round(ex_vol_df$volatility, 6), 6.975349)
 })
 
 test_that("returns error if no functional groups dataframe and no saving file and getting functional groups dataframe", {


### PR DESCRIPTION
In the `log_alpha` calculation (M/RT), 293K was used for temperature.  However, the coefficients for functional group contributions are based on 293.15K.  This changes the T to 293.15K and bumps the version to 1.0.1