### PR TITLE
Create pkgdown website for volcalc

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,6 @@ README.Rmd
 ^CITATION\.cff$
 ^CODE_OF_CONDUCT\.md$
 ^codecov\.yml$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,48 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 inst/doc
 /doc/
 /Meta/
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,3 +32,4 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+URL: https://meredith-lab.github.io/volcalc/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # volcalc (development version)
 
+* Added pkgdown website
+
 # volcalc 1.0.2
 
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://meredith-lab.github.io/volcalc/
+template:
+  bootstrap: 5
+

--- a/man/volcalc-package.Rd
+++ b/man/volcalc-package.Rd
@@ -8,6 +8,13 @@
 \description{
 Use this package to calculate estimated volatility values for individual compounds of interest or for all compounds in a pathway. Calculation uses the SIMPOL method (Prankow and Asher, 2008), and is only currently applicable to compounds and pathways in KEGG.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://meredith-lab.github.io/volcalc/}
+}
+
+}
 \author{
 \strong{Maintainer}: Kristina Riemer \email{kristinariemer@arizona.edu} (\href{https://orcid.org/0000-0003-3802-3331}{ORCID}) [copyright holder]
 


### PR DESCRIPTION
Creates a website for volcalc using `usethis::use_pkgdown_github_pages()` that, once merged, will be published at https://meredith-lab.github.io/volcalc/