### PR TITLE
Count only smallest rings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # volcalc (development version)
 
 * Added pkgdown website
+* `get_fx_groups()` now only counts the smallest set of smallest rings (#57)
 
 # volcalc 1.0.2
 

--- a/R/get_fx_groups.R
+++ b/R/get_fx_groups.R
@@ -40,7 +40,7 @@ get_fx_groups <-
     groups = "fctgroup",
     type = "countMA"
   )))
-  rings <- data.frame(t(ChemmineR::rings(compound_sdf, type = "count", arom = TRUE)))
+  rings <- data.frame(t(ChemmineR::rings(compound_sdf, type = "count", arom = TRUE, inner = TRUE)))
   atoms <- data.frame(t(unlist(ChemmineR::atomcount(compound_sdf))))
   carbon_bond_data <- data.frame(ChemmineR::conMA(compound_sdf)[[1]]) %>%
     dplyr::select(tidyselect::contains("C_")) %>%


### PR DESCRIPTION
Fix for #57 to only count smallest set of smallest rings in `get_fx_groups()`.  