### PR TITLE
install openbabel in pkgdown action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -29,6 +29,11 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+      
+      - name: Setup System Deps
+          run: |
+            sudo apt-get install libopenbabel-dev
+            sudo apt-get install libeigen3-dev
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
Seems like install of ChemmineOB was failing because OpenBabel was not installed.  Didn't realize this action needed to build the package