### PR TITLE
Enable SMILES input to `calc_vol()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # volcalc (development version)
 
+* It is now possible to supply input to `calc_vol()` as a vector of SMILES strings with `from = "smiles"`
+
 # volcalc 2.0.0
 
 This version includes big (breaking) changes in how the package works!  Please

--- a/R/calc_vol.R
+++ b/R/calc_vol.R
@@ -3,16 +3,15 @@
 #' Relative volatility value and category is estimated for specified compound
 #' using group contribution methods.
 #'
-#' @param input a path to a .mol file or a character representation such as
-#'   SMILES or InChI
-#' @param from the form of `input` (currently only a path to a .mol file is
-#'   implemented)
+#' @param input a path to a .mol file or a SMILES string.
+#' @param from the form of `input`. Either `"mol_path"` or `"smiles"` (default
+#'   is `"mol_path"`).
 #' @param method the method for calculating estimated volatility. Currently only
 #'   the SIMPOL.1 method is implemented---see [simpol1()] for more details.
 #' @param return_fx_groups When `TRUE`, includes functional group counts in
 #'   final dataframe.
 #' @param return_calc_steps When `TRUE`, includes intermediate volatility
-#'   calculation steps in final dataframe. See **Details**
+#'   calculation steps in final dataframe. See **Details**.
 #' 
 #' @details \eqn{\textrm{log}_{10}C^\ast} is used for the calculated relative
 #'   volatility index (`rvi`). \eqn{\textrm{log}_{10}C^\ast =
@@ -41,7 +40,7 @@
 #' 
 calc_vol <-
   function(input, 
-           from = c("mol_path"),
+           from = c("mol_path", "smiles"),
            method = c("simpol1"),
            return_fx_groups = FALSE,
            return_calc_steps = FALSE) {
@@ -52,13 +51,15 @@ calc_vol <-
     method <- match.arg(method)
     
     if(from == "mol_path") {
+      #TODO: validate mol files??
       compound_sdf_list <- lapply(input, ChemmineR::read.SDFset)
     }
     
     #TODO: needs testing before implementing
-    # if(from == "smiles") { 
-    #   compound_sdf_list <- lapply(input, ChemmineR::smiles2sdf)
-    # }
+    if(from == "smiles") {
+      #TODO: validate smiles
+      compound_sdf_list <- lapply(input, ChemmineR::smiles2sdf)
+    }
     
     fx_groups_df_list <-
       lapply(compound_sdf_list, get_fx_groups)

--- a/R/calc_vol.R
+++ b/R/calc_vol.R
@@ -55,9 +55,7 @@ calc_vol <-
       compound_sdf_list <- lapply(input, ChemmineR::read.SDFset)
     }
     
-    #TODO: needs testing before implementing
     if(from == "smiles") {
-      #TODO: validate smiles
       compound_sdf_list <- lapply(input, ChemmineR::smiles2sdf)
     }
     

--- a/R/get_fx_groups.R
+++ b/R/get_fx_groups.R
@@ -59,7 +59,7 @@ get_fx_groups <- function(compound_sdf) {
   #convert counts to integer
   groups <- groups %>% dplyr::mutate(dplyr::across(dplyr::everything(), as.integer))
   rings <- data.frame(t(ChemmineR::rings(compound_sdf, type = "count", arom = TRUE, inner = TRUE)))
-  atoms <- data.frame(t(unlist(ChemmineR::atomcount(compound_sdf))))
+  atoms <- atomcount2tibble(ChemmineR::atomcount(compound_sdf))
   carbon_bond_data <- data.frame(ChemmineR::conMA(compound_sdf)[[1]]) %>%
     dplyr::select(dplyr::contains("C_")) %>%
     tibble::rownames_to_column() %>%
@@ -99,8 +99,8 @@ get_fx_groups <- function(compound_sdf) {
     name = ChemmineR::propOB(compound_sdf)$title,
     mass = ChemmineR::propOB(compound_sdf)$MW, #TODO need to replace with NA if empty?
     #TODO these columns should all be integer
-    carbons = ifelse("CMP1.C" %in% colnames(atoms),
-                     atoms$CMP1.C, 0L
+    carbons = ifelse("C" %in% colnames(atoms),
+                     atoms$C, 0L
     ),
     carbons_asa = NA_integer_, #carbon number on the acid-side of amide
     rings_aromatic = rings$AROMATIC,

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,3 +3,24 @@
 zzz <- function() {
   ChemmineOB::prop_OB
 }
+
+
+#' Extracts first element of results of atomcount() as a tibble
+#' 
+#' ChemmineR::atomcount() returns a list of table objects, sometimes named,
+#' sometimes unnamed. Currently not taking advantage of the vectorization in
+#' ChemmineR and only allowing length 1 lists here.
+#'
+#' @param atomcount output of ChemmineR::atomcount()
+#'
+#' @return a tibble
+#' @noRd
+#' 
+atomcount2tibble <- function(atomcount) {
+  if (length(atomcount) != 1) {
+    stop("Only length 1 lists are allowed")
+  }
+  atomcount[[1]] %>% 
+    tibble::as_tibble_row() %>% 
+    dplyr::mutate(dplyr::across(dplyr::everything(), as.integer))
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -103,18 +103,20 @@ Use the package with:
 library(volcalc)
 ```
 
-## Single compound usage
+## Usage
 
-This is a basic example which shows you how to get an estimated relative volatility index (`rvi`) for an example compound *beta-2,3,4,5,6-Pentachlorocyclohexanol*.
-The KEGG compound identifier for the compound, as found on [the compound's KEGG page](https://www.genome.jp/dbget-bin/www_bget?C16181), is *C16181*.
+This is a basic example which shows you how to get an estimated relative volatility index (`rvi`) for two example compounds *beta-2,3,4,5,6-Pentachlorocyclohexanol*, and *Succinate*.
+The KEGG compound identifiers for the compounds, as found on [the compound's KEGG page](https://www.genome.jp/dbget-bin/www_bget?C16181), are C16181, and C00042.
 
-#### Single function approach
 
 ```{r}
 out_path <- tempdir()
 # download a .mol file from KEGG
-files <- get_mol_kegg("C16181", dir = out_path)
+files <- get_mol_kegg(c("C16181", "C00042"), dir = out_path)
 calc_vol(files$mol_path)
+
+#alternatively, supply a SMILES representation
+calc_vol(c("C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O",  "C(CC(=O)O)C(=O)O"), from = "smiles")
 ```
 
 This returns a dataframe with columns specifying general info about the compound, and the compound's calculated volatility and corresponding volatility category.

--- a/README.md
+++ b/README.md
@@ -113,25 +113,33 @@ Use the package with:
 library(volcalc)
 ```
 
-## Single compound usage
+## Usage
 
 This is a basic example which shows you how to get an estimated relative
-volatility index (`rvi`) for an example compound
-*beta-2,3,4,5,6-Pentachlorocyclohexanol*. The KEGG compound identifier
-for the compound, as found on [the compound’s KEGG
-page](https://www.genome.jp/dbget-bin/www_bget?C16181), is *C16181*.
-
-#### Single function approach
+volatility index (`rvi`) for two example compounds
+*beta-2,3,4,5,6-Pentachlorocyclohexanol*, and *Succinate*. The KEGG
+compound identifiers for the compounds, as found on [the compound’s KEGG
+page](https://www.genome.jp/dbget-bin/www_bget?C16181), are C16181, and
+C00042.
 
 ``` r
 out_path <- tempdir()
 # download a .mol file from KEGG
-files <- get_mol_kegg("C16181", dir = out_path)
+files <- get_mol_kegg(c("C16181", "C00042"), dir = out_path)
 calc_vol(files$mol_path)
-#> # A tibble: 1 × 5
+#> # A tibble: 2 × 5
 #>   mol_path                                          formula name    rvi category
 #>   <chr>                                             <chr>   <chr> <dbl> <chr>   
-#> 1 /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T… C6H7Cl… beta…  6.98 high
+#> 1 /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T… C6H7Cl… beta…  6.98 high    
+#> 2 /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T… C4H6O4  Succ…  2.57 high
+
+#alternatively, supply a SMILES representation
+calc_vol(c("C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O",  "C(CC(=O)O)C(=O)O"), from = "smiles")
+#> # A tibble: 2 × 5
+#>   smiles                        formula  name    rvi category
+#>   <chr>                         <chr>    <chr> <dbl> <chr>   
+#> 1 C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O C6H7Cl5O <NA>   6.98 high    
+#> 2 C(CC(=O)O)C(=O)O              C4H6O4   <NA>   2.57 high
 ```
 
 This returns a dataframe with columns specifying general info about the

--- a/man/calc_vol.Rd
+++ b/man/calc_vol.Rd
@@ -6,18 +6,17 @@
 \usage{
 calc_vol(
   input,
-  from = c("mol_path"),
+  from = c("mol_path", "smiles"),
   method = c("simpol1"),
   return_fx_groups = FALSE,
   return_calc_steps = FALSE
 )
 }
 \arguments{
-\item{input}{a path to a .mol file or a character representation such as
-SMILES or InChI}
+\item{input}{a path to a .mol file or a SMILES string.}
 
-\item{from}{the form of \code{input} (currently only a path to a .mol file is
-implemented)}
+\item{from}{the form of \code{input}. Either \code{"mol_path"} or \code{"smiles"} (default
+is \code{"mol_path"}).}
 
 \item{method}{the method for calculating estimated volatility. Currently only
 the SIMPOL.1 method is implemented---see \code{\link[=simpol1]{simpol1()}} for more details.}
@@ -26,7 +25,7 @@ the SIMPOL.1 method is implemented---see \code{\link[=simpol1]{simpol1()}} for m
 final dataframe.}
 
 \item{return_calc_steps}{When \code{TRUE}, includes intermediate volatility
-calculation steps in final dataframe. See \strong{Details}}
+calculation steps in final dataframe. See \strong{Details}.}
 }
 \value{
 a tibble with relative volatility index (\code{rvi}) and volatility

--- a/tests/testthat/test-calc_vol.R
+++ b/tests/testthat/test-calc_vol.R
@@ -18,6 +18,7 @@ test_that("calc_vol() works with multiple inputs", {
 })
 
 test_that("smiles and .mol give same results", {
+  #mol file is chiral and smiles is not, but shouldn't make a difference for group contribution methods
   expect_equal(
     calc_vol("C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O", from = "smiles") %>% dplyr::select(-name, -smiles),
     calc_vol("data/C16181.mol") %>% dplyr::select(-name, -mol_path)

--- a/tests/testthat/test-calc_vol.R
+++ b/tests/testthat/test-calc_vol.R
@@ -14,13 +14,20 @@ test_that("returns correct number of columns depending on return arguments", {
 
 test_that("calc_vol() works with multiple inputs", {
   paths <- c("data/map00361/C00011.mol", "data/map00361/C00042.mol")
+  smiles <- c("O=C=O", "C(CC(=O)O)C(=O)O")
   expect_s3_class(calc_vol(paths), "data.frame")
+  expect_s3_class(calc_vol(smiles, from = "smiles"), "data.frame")
 })
 
 test_that("smiles and .mol give same results", {
-  #mol file is chiral and smiles is not, but shouldn't make a difference for group contribution methods
+  paths <- c("data/C16181.mol", "data/map00361/C00011.mol", "data/map00361/C00042.mol")
+  smiles <- c("C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O", "O=C=O", "C(CC(=O)O)C(=O)O")
   expect_equal(
-    calc_vol("C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O", from = "smiles") %>% dplyr::select(-name, -smiles),
-    calc_vol("data/C16181.mol") %>% dplyr::select(-name, -mol_path)
+    calc_vol(smiles, from = "smiles") %>% dplyr::select(-name, -smiles),
+    calc_vol(paths) %>% dplyr::select(-name, -mol_path)
   )
+})
+
+test_that("errors with invalid SMILES", {
+  expect_error(calc_vol("hello", from = "smiles"))
 })

--- a/tests/testthat/test-calc_vol.R
+++ b/tests/testthat/test-calc_vol.R
@@ -16,4 +16,10 @@ test_that("calc_vol() works with multiple inputs", {
   paths <- c("data/map00361/C00011.mol", "data/map00361/C00042.mol")
   expect_s3_class(calc_vol(paths), "data.frame")
 })
-  
+
+test_that("smiles and .mol give same results", {
+  expect_equal(
+    calc_vol("C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O", from = "smiles") %>% dplyr::select(-name, -smiles),
+    calc_vol("data/C16181.mol") %>% dplyr::select(-name, -mol_path)
+  )
+})

--- a/tests/testthat/test-get_fx_groups.R
+++ b/tests/testthat/test-get_fx_groups.R
@@ -7,7 +7,17 @@ test_that("a functional group count is correct for example compound", {
 test_that("error with SDFset with more than one molecule", {
   data(sdfsample,package = "ChemmineR")
   sdfset <- sdfsample
-  expect_error(get_fx_groups(sdfset[1:4]), "SDFset objects must contain a single molecule only")
+  expect_error(get_fx_groups(sdfset[1:4]),
+               "SDFset objects must contain a single molecule only")
+})
+
+test_that("SMILES and mol give same results", {
+  from_mol <- ChemmineR::read.SDFset("data/C16181.mol")
+  from_smiles <- ChemmineR::smiles2sdf("C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O")
+  expect_equal(
+    get_fx_groups(from_mol) %>% dplyr::select(-name),
+    get_fx_groups(from_smiles) %>% dplyr::select(-name)
+  )
 })
 #' TODO:
 #' - Additional correctness tests


### PR DESCRIPTION
Adds the ability for `calc_vol()` to use SMILES strings as a starting point.  Adds some tests that mol and SMILES representations give the same results. 