### PR TITLE
Environment choice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # volcalc (development version)
 
 * It is now possible to supply input to `calc_vol()` as a vector of SMILES strings with `from = "smiles"`
+* Users can now choose from RVI thresholds for non-volatile, low, moderate, and high volatility for clean atmosphere, polluted atmosphere, or soil using the `environment` parameter of `calc_vol()
 
 # volcalc 2.0.0
 

--- a/R/calc_vol.R
+++ b/R/calc_vol.R
@@ -77,10 +77,12 @@ calc_vol <-
       lapply(compound_sdf_list, get_fx_groups)
     names(fx_groups_df_list) <- input
     fx_groups_df <- 
-      dplyr::bind_rows(fx_groups_df_list, .id = {{from}}) #adds column for input named "mol_path" or "smiles"
+      #adds column for input named "mol_path" or "smiles"
+      dplyr::bind_rows(fx_groups_df_list, .id = {{from}}) 
     
-    # calculate relative volatility & categories from logP
-    vol_df <- simpol1(fx_groups_df) %>% 
+    vol_df <- 
+      simpol1(fx_groups_df) %>% 
+      # calculate relative volatility & categories from logP
       dplyr::mutate(
         # mass is converted from grams to micrograms
         # 0.0000821 is universal gas constant
@@ -88,7 +90,7 @@ calc_vol <-
         log_alpha = log10((1000000 * .data$mass) / (0.0000821 * 293.15)),
         rvi = .data$log_alpha + .data$log10_P, 
         category = cut(
-          rvi,
+          .data$rvi,
           breaks = cutoffs,
           labels = c("non-volatile", "low", "moderate", "high"),
           right = FALSE

--- a/R/calc_vol.R
+++ b/R/calc_vol.R
@@ -8,6 +8,10 @@
 #'   is `"mol_path"`).
 #' @param method the method for calculating estimated volatility. Currently only
 #'   the SIMPOL.1 method is implemented---see [simpol1()] for more details.
+#' @param environment the environment for calculating relative volatility
+#'   categories. RVI thresholds for low, moderate, and high volatility are as
+#'   follows: `"clean"` (clean atmosphere, default) -2, 0, 2; `"polluted"`
+#'   (polluted atmosphere) 0, 2, 4; `"soil"` 4, 6, 8.
 #' @param return_fx_groups When `TRUE`, includes functional group counts in
 #'   final dataframe.
 #' @param return_calc_steps When `TRUE`, includes intermediate volatility
@@ -42,6 +46,7 @@ calc_vol <-
   function(input, 
            from = c("mol_path", "smiles"),
            method = c("simpol1"),
+           environment = c("clean", "polluted", "soil"),
            return_fx_groups = FALSE,
            return_calc_steps = FALSE) {
     
@@ -49,6 +54,15 @@ calc_vol <-
     #for future extensions in case other methods are added
     
     method <- match.arg(method)
+    
+    environment <- match.arg(environment)
+    
+    cutoffs <- switch(
+      environment,
+      "clean" = c(-Inf, -2, 0, 2, Inf),
+      "polluted" = c(-Inf, 0, 2, 4, Inf),
+      "soil" = c(-Inf, 4, 6, 8, Inf)
+    )
     
     if(from == "mol_path") {
       #TODO: validate mol files??
@@ -73,12 +87,11 @@ calc_vol <-
         # 293.15 is temperature in Kelvins (20ºC)
         log_alpha = log10((1000000 * .data$mass) / (0.0000821 * 293.15)),
         rvi = .data$log_alpha + .data$log10_P, 
-        #TODO add @details to documentation explaining categories.  Make sure they match manuscript
-        category = dplyr::case_when(
-          .data$rvi <  -2                 ~ "non",
-          .data$rvi >= -2 & .data$rvi < 0 ~ "low",
-          .data$rvi >= 0  & .data$rvi < 2 ~ "intermediate",
-          .data$rvi >= 2                  ~ "high"
+        category = cut(
+          rvi,
+          breaks = cutoffs,
+          labels = c("non-volatile", "low", "moderate", "high"),
+          right = FALSE
         )
       )
     

--- a/man/calc_vol.Rd
+++ b/man/calc_vol.Rd
@@ -8,6 +8,7 @@ calc_vol(
   input,
   from = c("mol_path", "smiles"),
   method = c("simpol1"),
+  environment = c("clean", "polluted", "soil"),
   return_fx_groups = FALSE,
   return_calc_steps = FALSE
 )
@@ -20,6 +21,11 @@ is \code{"mol_path"}).}
 
 \item{method}{the method for calculating estimated volatility. Currently only
 the SIMPOL.1 method is implemented---see \code{\link[=simpol1]{simpol1()}} for more details.}
+
+\item{environment}{the environment for calculating relative volatility
+categories. RVI thresholds for low, moderate, and high volatility are as
+follows: \code{"clean"} (clean atmosphere, default) -2, 0, 2; \code{"polluted"}
+(polluted atmosphere) 0, 2, 4; \code{"soil"} 4, 6, 8.}
 
 \item{return_fx_groups}{When \code{TRUE}, includes functional group counts in
 final dataframe.}


### PR DESCRIPTION
Addresses #37 by adding a new parameter, `environment` to `calc_vol()`.  This PR also replaces the categorization with `dplyr::case_when()` with a simpler method using `cut()`.  A side-effect of this is that now the `category` column is a factor, which seems appropriate.