### PR TITLE
Add exact mass to output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * It is now possible to supply input to `calc_vol()` as a vector of SMILES strings with `from = "smiles"`
 * Users can now choose from RVI thresholds for non-volatile, low, moderate, and high volatility for clean atmosphere, polluted atmosphere, or soil using the `environment` parameter of `calc_vol()
+* Chagnes to the output of `get_fx_groups()`: `mass` column renamed to `molecular_weight` and addition of an `exact_mass` column
 
 # volcalc 2.0.0
 

--- a/R/calc_vol.R
+++ b/R/calc_vol.R
@@ -87,7 +87,7 @@ calc_vol <-
         # mass is converted from grams to micrograms
         # 0.0000821 is universal gas constant
         # 293.15 is temperature in Kelvins (20ºC)
-        log_alpha = log10((1000000 * .data$mass) / (0.0000821 * 293.15)),
+        log_alpha = log10((1000000 * .data$molecular_weight) / (0.0000821 * 293.15)),
         rvi = .data$log_alpha + .data$log10_P, 
         category = cut(
           .data$rvi,
@@ -101,11 +101,12 @@ calc_vol <-
     cols_fx <- NULL
     cols_calc <- NULL
     if (isTRUE(return_fx_groups)) {
-      cols_fx <- colnames(fx_groups_df)[!colnames(fx_groups_df) %in% c("formula", "name", "mass")]
+      cols_fx <- 
+        colnames(fx_groups_df)[!colnames(fx_groups_df) %in% c("formula", "name", "molecular_weight")]
     }
     if (isTRUE(return_calc_steps)) {
       #TODO document log_alpha (need to figure out why it's called that first)
-      cols_calc <- c("mass", "log_alpha", "log10_P")
+      cols_calc <- c("molecular_weight", "log_alpha", "log10_P")
     }
     
     #return:

--- a/R/get_fx_groups.R
+++ b/R/get_fx_groups.R
@@ -97,7 +97,8 @@ get_fx_groups <- function(compound_sdf) {
     formula = ChemmineR::propOB(compound_sdf)$formula,
     #TODO should name be moved to `calc_vol`? `formula` also?
     name = ChemmineR::propOB(compound_sdf)$title,
-    mass = ChemmineR::propOB(compound_sdf)$MW, #TODO need to replace with NA if empty?
+    exact_mass = ChemmineR::exactMassOB(compound_sdf),
+    molecular_weight = ChemmineR::propOB(compound_sdf)$MW, #TODO need to replace with NA if empty?
     #TODO these columns should all be integer
     carbons = ifelse("C" %in% colnames(atoms),
                      atoms$C, 0L

--- a/README.Rmd
+++ b/README.Rmd
@@ -132,7 +132,7 @@ The functional group counts underlying the volatility can be additionally return
 -   compound: KEGG compound identifier
 -   formula: compound chemical formula
 -   name: compound name
--   mass: compound mass
+-   molecular_weight: molecular weight
 
 ### Counted functional groups and atoms
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ and the intermediate calculation steps with `return_calc_steps = TRUE`.
 -   compound: KEGG compound identifier
 -   formula: compound chemical formula
 -   name: compound name
--   mass: compound mass
+-   molecular_weight: molecular weight
 &#10;### Counted functional groups and atoms
 &#10;-   carbons
 -   ketones

--- a/tests/testthat/test-calc_vol.R
+++ b/tests/testthat/test-calc_vol.R
@@ -4,12 +4,14 @@ test_that("volatility estimate is correct for example compound for entire workfl
 })
 
 
-test_that("returns correct number of columns depending on return arguments", {
-  expect_equal(ncol(calc_vol("data/C16181.mol")), 5)
-  expect_equal(ncol(calc_vol("data/C16181.mol", return_fx_groups = TRUE)), 47)
-  expect_equal(ncol(calc_vol("data/C16181.mol", return_calc_steps = TRUE)), 8)
-  expect_equal(ncol(calc_vol("data/C16181.mol", return_fx_groups = TRUE,
-                             return_calc_steps = TRUE)), 50)
+test_that("returns correct columns depending on return arguments", {
+  just_vol <- calc_vol("data/C16181.mol")
+  with_fx <- calc_vol("data/C16181.mol", return_fx_groups = TRUE)
+  with_fx_steps <- calc_vol("data/C16181.mol", return_fx_groups = TRUE, return_calc_steps = TRUE)
+  expect_setequal(colnames(just_vol), c("mol_path", "formula", "name", "rvi", "category"))
+  # just some examples here
+  expect_contains(colnames(with_fx), c(colnames(just_vol), "carbons", "carbothioester", "fluorines"))
+  expect_contains(colnames(with_fx_steps), c(colnames(with_fx), "molecular_weight", "log_alpha", "log10_P"))
 })
 
 test_that("calc_vol() works with multiple inputs", {


### PR DESCRIPTION
Re-names `mass` to `molecular_weight` and adds `exact_mass` to output of `get_fx_groups()` and `calc_vol(... , return_fx_groups = TRUE)`.  Closes #45 