### PR TITLE
Fix for #91

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,9 +13,6 @@
 * `mol_example()` no longer takes any arguments and just returns file paths to all example .mol files.
 * The manuscript associated with `volcalc` is now published in Frontiers in Microbiology 🎉. DOI: 10.3389/fmicb.2023.1267234
 
-## Bug Fixes
-
-* Fixed a serious bug that was making all values of `log10_P` the same when `simpol1` was used on a dataframe with multiple compounds (#81).
 
 # volcalc 2.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 * `mol_example()` no longer takes any arguments and just returns file paths to all example .mol files.
 * The manuscript associated with `volcalc` is now published in Frontiers in Microbiology 🎉. DOI: 10.3389/fmicb.2023.1267234
 
+## Bug Fixes
+
+* Fixed a serious bug that was making all values of `log10_P` the same when `simpol1` was used on a dataframe with multiple compounds (#81).
+
 # volcalc 2.0.0
 
 This version includes big (breaking) changes in how the package works!  Please

--- a/R/simpol1.R
+++ b/R/simpol1.R
@@ -109,6 +109,8 @@ simpol1 <- function(fx_groups, meredith = TRUE) {
   }
   
   betas %>% 
+    dplyr::rowwise() %>% 
     dplyr::mutate(log10_P = sum(dplyr::c_across(dplyr::starts_with("b_")))) %>% 
+    dplyr::ungroup() %>% 
     dplyr::select(-dplyr::starts_with("b_"))
 }

--- a/tests/testthat/test-calc_vol.R
+++ b/tests/testthat/test-calc_vol.R
@@ -35,9 +35,10 @@ test_that("errors with invalid SMILES", {
   
 test_that("meredith and original method give different results", {
   #thiol and sulfonate groups, respectively
-  paths <- c("data/C00409.mol", "data/C03349.mol")
-  meredith <- calc_vol(paths, method = "meredith")
-  simpol   <- calc_vol(paths, method = "simpol1")
+  # paths <- c(test_path("data/C00409.mol"), test_path("data/C03349.mol"))
+  smiles <- c("Methanethiol" = "SC", "Methyl methanesulfonate" = "COS(=O)(=O)C")
+  meredith <- calc_vol(smiles, from = "smiles", method = "meredith")
+  simpol   <- calc_vol(smiles, from = "smiles", method = "simpol1")
   expect_true(all(meredith$rvi < simpol$rvi))
 })
 

--- a/tests/testthat/test-simpol1.R
+++ b/tests/testthat/test-simpol1.R
@@ -1,0 +1,17 @@
+test_that("isoprene is more volatile than glucose", {
+  isoprene <- ChemmineR::read.SDFset(mol_example()[5])
+  glucose  <- ChemmineR::read.SDFset(mol_example()[1])
+  
+  log10P_together <- simpol1(dplyr::bind_rows(
+    get_fx_groups(isoprene),
+    get_fx_groups(glucose)
+  ))$log10_P
+  
+  log10P_separate <- c(
+    simpol1(get_fx_groups(isoprene))$log10_P,
+    simpol1(get_fx_groups(glucose))$log10_P
+  )
+  
+  expect_gt(log10P_together[1], log10P_together[2])
+  expect_equal(log10P_together, log10P_separate)
+})


### PR DESCRIPTION
Fixes #91 by adding a `rowwise()` in `simpol1()` to sum across columns correctly.  Also adds tests to guard against reversion.

Didn't add this to NEWS.md because the bug was introduced in this version.