### PR TITLE
Copy SystemRequirements from ChemmineOB

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     withr
+SystemRequirements: OpenBabel (>= 3.0.0) with headers (http://openbabel.org). Eigen3 with headers.
 biocViews: 
 Config/testthat/edition: 3
 Encoding: UTF-8


### PR DESCRIPTION
I'm trying to address failing macOS builds on r-universe (#74).  I'm not sure if this will help.  OpenBabel doesn't show up as a system requirement for volcalc in r-universe, but I'm not sure that it needs to.  I would guess that it would only need to be a requirement for `ChemmineOB` which `volcalc` has in Imports.  If this doesn't work, we can revert it.