### PR TITLE
WIP: move ChemmineOB to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,4 +47,4 @@ biocViews:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ License: MIT + file LICENSE
 URL: https://meredith-lab.github.io/volcalc/
 BugReports: https://github.com/Meredith-Lab/volcalc/issues
 Imports: 
-    ChemmineOB,
     ChemmineR,
     dplyr,
     fs,
@@ -35,6 +34,7 @@ Imports:
     tidyr,
     tidyselect
 Suggests: 
+    ChemmineOB,
     knitr,
     processx,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ License: MIT + file LICENSE
 URL: https://meredith-lab.github.io/volcalc/
 BugReports: https://github.com/Meredith-Lab/volcalc/issues
 Imports: 
-    BiocManager,
     ChemmineR,
     dplyr,
     fs,
@@ -28,6 +27,7 @@ Imports:
     httr2,
     KEGGREST,
     magrittr,
+    pak,
     purrr,
     rlang,
     stringr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ License: MIT + file LICENSE
 URL: https://meredith-lab.github.io/volcalc/
 BugReports: https://github.com/Meredith-Lab/volcalc/issues
 Imports: 
+    BiocManager,
     ChemmineR,
     dplyr,
     fs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # volcalc (development version)
 
-* Changed `ChemmineOB` from a hard to soft dependency (moved from Imports to Suggests) to satisfy CRAN checks. Users will be prompted to install `ChemmineOB` the fist time `get_fx_groups()` or `calc_vol()` are run if they don't already have it installed.
+* Changed `ChemmineOB` from a hard to soft dependency (moved from Imports to Suggests) to satisfy CRAN checks. Users will be prompted to install `ChemmineOB` the fist time `get_fx_groups()` or `calc_vol()` are run if they don't already have it installed. To make this work, `BiocManager` was added as a dependency.
 
 # volcalc 2.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # volcalc (development version)
 
-* Changed `ChemmineOB` from a hard to soft dependency (moved from Imports to Suggests) to satisfy CRAN checks. Users will be prompted to install `ChemmineOB` the fist time `get_fx_groups()` or `calc_vol()` are run if they don't already have it installed. To make this work, `BiocManager` was added as a dependency.
+* Changed `ChemmineOB` from a hard to soft dependency (moved from Imports to Suggests) to satisfy CRAN checks. Users will be prompted to install `ChemmineOB` the fist time `get_fx_groups()` or `calc_vol()` are run if they don't already have it installed. To make this work, `pak` was added as a dependency.
 
 # volcalc 2.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # volcalc (development version)
 
+* Changed `ChemmineOB` from a hard to soft dependency (moved from Imports to Suggests) to satisfy CRAN checks. Users will be prompted to install `ChemmineOB` the fist time `get_fx_groups()` or `calc_vol()` are run if they don't already have it installed.
+
 # volcalc 2.1.1
 
 * Added Dr. Laura Meredith as a package author as the concept for volcalc originated from her.

--- a/R/get_fx_groups.R
+++ b/R/get_fx_groups.R
@@ -16,12 +16,16 @@
 #'   counts.
 #' @seealso [calc_vol()]
 #' @examples
-#' mol_path <- mol_example()[1]
-#' sdf <- ChemmineR::read.SDFset(mol_path)
-#' get_fx_groups(sdf)
+#' if (rlang::is_installed("ChemmineOB")) {
+#'   mol_path <- mol_example()[1]
+#'   sdf <- ChemmineR::read.SDFset(mol_path)
+#'   get_fx_groups(sdf)
+#' }
 #' 
 #' @export
 get_fx_groups <- function(compound_sdf) {
+  # Check that ChemmineOB is installed
+  rlang::check_installed("ChemmineOB", action = BiocManager::install)
   
   # For now at least, this code only works with SDFset objects that contain
   # single molecules. 

--- a/R/get_fx_groups.R
+++ b/R/get_fx_groups.R
@@ -25,7 +25,7 @@
 #' @export
 get_fx_groups <- function(compound_sdf) {
   # Check that ChemmineOB is installed
-  rlang::check_installed("ChemmineOB", action = BiocManager::install)
+  rlang::check_installed("ChemmineOB", action = pak::pak)
   
   # For now at least, this code only works with SDFset objects that contain
   # single molecules. 

--- a/R/release_bullets.R
+++ b/R/release_bullets.R
@@ -2,6 +2,6 @@
 release_bullets <- function() {
   c(
     "Increment version in CITATION.cff and CITATION",
-    "run vignettes/precompute.R script to precompute KEGG vignette"
+    "run vignettes/precompute.R script to precompute vignettes"
   )
 }

--- a/R/simpol1.R
+++ b/R/simpol1.R
@@ -46,10 +46,12 @@
 #' @export
 #'
 #' @examples
-#' mol_path <- mol_example()[3]
-#' sdf <- ChemmineR::read.SDFset(mol_path)
-#' fx_groups <- get_fx_groups(sdf)
-#' simpol1(fx_groups)
+#' if (rlang::is_installed("ChemmineOB")) {
+#'   mol_path <- mol_example()[3]
+#'   sdf <- ChemmineR::read.SDFset(mol_path)
+#'   fx_groups <- get_fx_groups(sdf)
+#'   simpol1(fx_groups)
+#' }
 simpol1 <- function(fx_groups, meredith = TRUE) {
   betas <- fx_groups %>%
     # assume NAs are 0s for the sake of this calculation

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,12 +1,5 @@
 utils::globalVariables(".data")
 
-# This only exists to silence a R CMD check note about ChemmineOB being in
-# Imports but no functions being used in volcalc directly.
-zzz <- function() {
-  ChemmineOB::prop_OB
-}
-
-
 #' Extracts first element of results of atomcount() as a tibble
 #' 
 #' ChemmineR::atomcount() returns a list of table objects, sometimes named,

--- a/README.Rmd
+++ b/README.Rmd
@@ -57,8 +57,8 @@ You can install the 'legacy' version used in Meredith et al. (2023) with
 pak::pkg_install("Meredith-Lab/volcalc@v1.0.2")
 ```
 
-Installation of `volcalc` requires the system libraries [OpenBabel](https://open-babel.readthedocs.io/) and Eigen3 (requirements of the `ChemmineOB` package, which `volcalc` depends on).
-`pak` will take care of the installation of these libraries for you on some systems, but you may need to install them manually on some operating systems.
+To use the main functionality of `volcalc`, you will also need to install the `ChemmineOB` package (if you don't have it installed, you will be prompted to install it upon first use of `calc_vol()`).  `ChemmineOB` requires the system libraries [OpenBabel](https://open-babel.readthedocs.io/) and Eigen3 on all platforms except Windows.
+Depending on how you install `ChemmineOB`, you may need to install these system dependencies manually.
 
 For macOS, they can be installed via homebrew by running the following shell command:
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ You can install the ‘legacy’ version used in Meredith et al. (2023) with
 pak::pkg_install("Meredith-Lab/volcalc@v1.0.2")
 ```
 
-Installation of `volcalc` requires the system libraries
-[OpenBabel](https://open-babel.readthedocs.io/) and Eigen3 (requirements
-of the `ChemmineOB` package, which `volcalc` depends on). `pak` will
-take care of the installation of these libraries for you on some
-systems, but you may need to install them manually on some operating
-systems.
+To use the main functionality of `volcalc`, you will also need to
+install the `ChemmineOB` package (if you don’t have it installed, you
+will be prompted to install it upon first use of `calc_vol()`).
+`ChemmineOB` requires the system libraries
+[OpenBabel](https://open-babel.readthedocs.io/) and Eigen3 on all
+platforms except Windows. Depending on how you install `ChemmineOB`, you
+may need to install these system dependencies manually.
 
 For macOS, they can be installed via homebrew by running the following
 shell command:
@@ -157,9 +158,9 @@ reference below:
 citation("volcalc")
 #> To cite volcalc in publications please use:
 #> 
-#>   Riemer K, Scott E (2023). _volcalc: Calculate Volatility of Chemical
-#>   Compounds_. doi:10.5281/zenodo.8015155
-#>   <https://doi.org/10.5281/zenodo.8015155>, R package version 2.0.0.
+#>   Riemer K, Scott E, Meredith L (2023). _volcalc: Calculate Volatility
+#>   of Chemical Compounds_. doi:10.5281/zenodo.8015155
+#>   <https://doi.org/10.5281/zenodo.8015155>, R package version 2.1.1.
 #> 
 #> Please also cite the related manuscript:
 #> 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -11,3 +11,10 @@ The note on check is:
 >    ChemmineOB
 
 ChemmineOB is an R package with the [Artistic-2.0 license](https://github.com/girke-lab/ChemmineOB/blob/master/LICENSE), which does appear to be FOSS.  Other R packages
+
+There was an error on the CRAN pre-test on an initial submission on Debian:
+
+>* checking package dependencies ... ERROR
+Package required but not available: ‘ChemmineOB’
+
+I've confirmed that `ChemmineOB` is available and can be installed on Debian using rocker/r-devel. I assume this actually means that the installation of `ChemmineOB` errored due to missing system dependencies (OpenBabel and eigen3).  In response, we've moved `ChemmineOB` from Imports to Suggests, checked that it is installed before functions from it are called, and conditionally skipped tests and examples when `ChemmineOB` is not installed.

--- a/man/get_fx_groups.Rd
+++ b/man/get_fx_groups.Rd
@@ -26,9 +26,11 @@ Contributions of SMARTS strings or other methods to capture this
 "functional group" are welcome.
 }
 \examples{
-mol_path <- mol_example()[1]
-sdf <- ChemmineR::read.SDFset(mol_path)
-get_fx_groups(sdf)
+if (rlang::is_installed("ChemmineOB")) {
+  mol_path <- mol_example()[1]
+  sdf <- ChemmineR::read.SDFset(mol_path)
+  get_fx_groups(sdf)
+}
 
 }
 \seealso{

--- a/man/simpol1.Rd
+++ b/man/simpol1.Rd
@@ -46,10 +46,12 @@ calculations of logP at different temperatures.  This implementation
 currently only calculates values at 20ºC.
 }
 \examples{
-mol_path <- mol_example()[3]
-sdf <- ChemmineR::read.SDFset(mol_path)
-fx_groups <- get_fx_groups(sdf)
-simpol1(fx_groups)
+if (rlang::is_installed("ChemmineOB")) {
+  mol_path <- mol_example()[3]
+  sdf <- ChemmineR::read.SDFset(mol_path)
+  fx_groups <- get_fx_groups(sdf)
+  simpol1(fx_groups)
+}
 }
 \references{
 Meredith L, Ledford S, Riemer K, Geffre P, Graves K, Honeker L, LeBauer D,

--- a/tests/testthat/test-calc_vol.R
+++ b/tests/testthat/test-calc_vol.R
@@ -1,9 +1,11 @@
 test_that("volatility estimate is correct", {
+  skip_if_not_installed("ChemmineOB")
   ex_vol_df <- calc_vol("data/C16181.mol")
   expect_equal(round(ex_vol_df$rvi, 6), 6.975349)
 })
 
 test_that("returns correct columns depending on return arguments", {
+  skip_if_not_installed("ChemmineOB")
   just_vol <- calc_vol("data/C16181.mol")
   with_fx <- calc_vol("data/C16181.mol", return_fx_groups = TRUE)
   with_fx_steps <-
@@ -20,6 +22,7 @@ test_that("returns correct columns depending on return arguments", {
 })
 
 test_that("calc_vol() works with multiple inputs", {
+  skip_if_not_installed("ChemmineOB")
   paths <- c("data/map00361/C00011.mol", "data/map00361/C00042.mol")
   smiles <- c("O=C=O", "C(CC(=O)O)C(=O)O")
   expect_s3_class(calc_vol(paths), "data.frame")
@@ -27,6 +30,7 @@ test_that("calc_vol() works with multiple inputs", {
 })
 
 test_that("smiles and .mol give same results", {
+  skip_if_not_installed("ChemmineOB")
   paths <-
     c("data/C16181.mol",
       "data/map00361/C00011.mol",
@@ -40,10 +44,12 @@ test_that("smiles and .mol give same results", {
 })
 
 test_that("errors with invalid SMILES", {
+  skip_if_not_installed("ChemmineOB")
   expect_error(calc_vol("hello", from = "smiles"))
 })
   
 test_that("meredith and original method give different results", {
+  skip_if_not_installed("ChemmineOB")
   #thiol and sulfonate groups, respectively
   # paths <- c(test_path("data/C00409.mol"), test_path("data/C03349.mol"))
   smiles <-

--- a/tests/testthat/test-get_fx_groups.R
+++ b/tests/testthat/test-get_fx_groups.R
@@ -1,10 +1,12 @@
 test_that("a functional group count is correct for example compound", {
+  skip_if_not_installed("ChemmineOB")
   sdf <- ChemmineR::read.SDFset(test_path("data/C16181.mol"))
   ex_df <- get_fx_groups(sdf)
   expect_equal(ex_df$hydroxyl_aliphatic, 1, ignore_attr = TRUE)
 })
 
 test_that("error with SDFset with more than one molecule", {
+  skip_if_not_installed("ChemmineOB")
   data(sdfsample,package = "ChemmineR")
   sdfset <- sdfsample
   expect_error(get_fx_groups(sdfset[1:4]),
@@ -12,6 +14,7 @@ test_that("error with SDFset with more than one molecule", {
 })
 
 test_that("SMILES and mol give same results", {
+  skip_if_not_installed("ChemmineOB")
   from_mol <- ChemmineR::read.SDFset(test_path("data/C16181.mol"))
   from_smiles <- ChemmineR::smiles2sdf("C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O")
   expect_equal(
@@ -22,6 +25,7 @@ test_that("SMILES and mol give same results", {
 })
 
 test_that("SMARTS strings are correct", {
+  skip_if_not_installed("ChemmineOB")
   # correctness tests compare output of get_fx_groups() to a manually edited
   # .csv file at "tests/testthat/data/test_compounds.csv".  Add compounds to
   # that file with counts of functional groups using the same column names as

--- a/tests/testthat/test-simpol1.R
+++ b/tests/testthat/test-simpol1.R
@@ -1,4 +1,5 @@
 test_that("isoprene is more volatile than glucose", {
+  skip_if_not_installed("ChemmineOB")
   isoprene <- ChemmineR::read.SDFset(mol_example()[5])
   glucose  <- ChemmineR::read.SDFset(mol_example()[1])
   

--- a/vignettes/kegg.Rmd
+++ b/vignettes/kegg.Rmd
@@ -15,14 +15,6 @@ vignette: >
 ```r
 library(volcalc)
 library(dplyr) #for left_join()
-#> 
-#> Attaching package: 'dplyr'
-#> The following objects are masked from 'package:stats':
-#> 
-#>     filter, lag
-#> The following objects are masked from 'package:base':
-#> 
-#>     intersect, setdiff, setequal, union
 ```
 
 The `volcalc` package can be used to download .mol files directly from KEGG given either compound IDs or pathway IDs.
@@ -45,10 +37,10 @@ Let's download .mol files for two compounds, jasmonic acid and methyl jasmonate,
 mols <- get_mol_kegg(compound_ids = c("C08491", "C11512"), dir = dl_path)
 mols
 #> # A tibble: 2 × 2
-#>   compound_id mol_path                                    
-#>   <chr>       <fs::path>                                  
-#> 1 C08491      …6hb9xvfqc5ht80000gp/T/Rtmp4LsL5W/C08491.mol
-#> 2 C11512      …6hb9xvfqc5ht80000gp/T/Rtmp4LsL5W/C11512.mol
+#>   compound_id mol_path                                                              
+#>   <chr>       <fs::path>                                                            
+#> 1 C08491      /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/C08491.mol
+#> 2 C11512      /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/C11512.mol
 ```
 
 The data frame returned by `get_mol_kegg()` contains the paths the files were downloaded to in `mol_path`, making for convenient passage on to the `volcalc` function `calc_vol()`.
@@ -58,10 +50,10 @@ The data frame returned by `get_mol_kegg()` contains the paths the files were do
 rvi <- calc_vol(mols$mol_path)
 rvi
 #> # A tibble: 2 × 5
-#>   mol_path                    formula name    rvi category
-#>   <chr>                       <chr>   <chr> <dbl> <fct>   
-#> 1 /var/folders/pf/rjm3plcx14… C12H18… (-)-…  1.84 moderate
-#> 2 /var/folders/pf/rjm3plcx14… C13H20… Meth…  3.81 high
+#>   mol_path                                                               formula  name             rvi category
+#>   <chr>                                                                  <chr>    <chr>          <dbl> <fct>   
+#> 1 /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/C08491.mol C12H18O3 (-)-Jasmonic …  1.84 moderate
+#> 2 /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/C11512.mol C13H20O3 Methyl jasmon…  3.81 high
 ```
 
 `calc_vol()` also returns the file paths, so these two data frames can be easily joined.
@@ -88,14 +80,14 @@ We can download single or multiple compounds with `compound_ids`, but we can als
 alam_pathway <- get_mol_kegg(pathway_ids = "map00592", dir = dl_path)
 head(alam_pathway)
 #> # A tibble: 6 × 3
-#>   pathway_id compound_id mol_path                         
-#>   <chr>      <chr>       <fs::path>                       
-#> 1 map00592   C00157      …T/Rtmp4LsL5W/map00592/C00157.mol
-#> 2 map00592   C01226      …T/Rtmp4LsL5W/map00592/C01226.mol
-#> 3 map00592   C04672      …T/Rtmp4LsL5W/map00592/C04672.mol
-#> 4 map00592   C04780      …T/Rtmp4LsL5W/map00592/C04780.mol
-#> 5 map00592   C04785      …T/Rtmp4LsL5W/map00592/C04785.mol
-#> 6 map00592   C06427      …T/Rtmp4LsL5W/map00592/C06427.mol
+#>   pathway_id compound_id mol_path                                                                       
+#>   <chr>      <chr>       <fs::path>                                                                     
+#> 1 map00592   C00157      /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/map00592/C00157.mol
+#> 2 map00592   C01226      /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/map00592/C01226.mol
+#> 3 map00592   C04672      /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/map00592/C04672.mol
+#> 4 map00592   C04780      /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/map00592/C04780.mol
+#> 5 map00592   C04785      /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/map00592/C04785.mol
+#> 6 map00592   C06427      /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T/RtmpKO0Avo/map00592/C06427.mol
 dim(alam_pathway)
 #> [1] 44  3
 ```
@@ -117,17 +109,17 @@ left_join(alam_pathway, rvi_path, by = join_by(mol_path)) %>%
   #take just the top 10
   slice_head(n = 10)
 #> # A tibble: 10 × 6
-#>    pathway_id compound_id formula    name     rvi category
-#>    <chr>      <chr>       <chr>      <chr>  <dbl> <fct>   
-#>  1 map00592   C16310      C6H10O     3-Hex…  7.32 high    
-#>  2 map00592   C19757      C8H14O2    (3Z)-…  6.75 high    
-#>  3 map00592   C08492      C6H12O     3-Hex…  6.45 high    
-#>  4 map00592   C16323      C9H14O     3,6-N…  6.05 high    
-#>  5 map00592   C11512      C13H20O3   Methy…  3.81 high    
-#>  6 map00592   C16318      C13H20O3   (+)-7…  3.81 high    
-#>  7 map00592   C00157      C10H18NO8P Phosp…  2.89 high    
-#>  8 map00592   C16322      C9H16O3    9-Oxo…  2.77 high    
-#>  9 map00592   C16343      C17H28O    Hepta…  2.69 high    
-#> 10 map00592   C08491      C12H18O3   (-)-J…  1.84 moderate
+#>    pathway_id compound_id formula    name                         rvi category
+#>    <chr>      <chr>       <chr>      <chr>                      <dbl> <fct>   
+#>  1 map00592   C16310      C6H10O     3-Hexenal                   7.32 high    
+#>  2 map00592   C19757      C8H14O2    (3Z)-Hex-3-en-1-yl acetate  6.75 high    
+#>  3 map00592   C08492      C6H12O     3-Hexenol                   6.45 high    
+#>  4 map00592   C16323      C9H14O     3,6-Nonadienal              6.05 high    
+#>  5 map00592   C11512      C13H20O3   Methyl jasmonate            3.81 high    
+#>  6 map00592   C16318      C13H20O3   (+)-7-Isomethyljasmonate    3.81 high    
+#>  7 map00592   C00157      C10H18NO8P Phosphatidylcholine         2.89 high    
+#>  8 map00592   C16322      C9H16O3    9-Oxononanoic acid          2.77 high    
+#>  9 map00592   C16343      C17H28O    Heptadecatrienal            2.69 high    
+#> 10 map00592   C08491      C12H18O3   (-)-Jasmonic acid           1.84 moderate
 ```
 

--- a/vignettes/precompute.R
+++ b/vignettes/precompute.R
@@ -1,2 +1,3 @@
 #https://ropensci.org/blog/2019/12/08/precompute-vignettes/
 knitr::knit("vignettes/kegg-source.Rmd.source", output = "vignettes/kegg.Rmd")
+knitr::knit("vignettes/volcalc-source.Rmd.source", output = "vignettes/volcalc.Rmd")

--- a/vignettes/volcalc-source.Rmd.source
+++ b/vignettes/volcalc-source.Rmd.source
@@ -1,0 +1,78 @@
+---
+title: "Introduction to volcalc"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Introduction to volcalc}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+<!-- generated from volcalc-source.Rmd.source.  Please edit that file! -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(volcalc)
+```
+
+The primary function in `volcalc` is `calc_vol()`.  It accepts either a path to a .mol file or a SMILES string.  There are a few example .mol files included in the `volcalc` installation and their file paths are returned by `mol_example()`.
+
+### Basic usage with .mol files
+
+```{r}
+#using built-in example .mol files
+mol_paths <- mol_example()
+mol_paths
+```
+
+The default output of `calc_vol()` includes a relative volatility index, `rvi` which is equivalent to $\textrm{log}_{10}C^\ast$ (Meredith et al., 2023).  It also includes a RVI category for clean air.
+
+```{r}
+calc_vol(mol_paths)
+```
+
+### Specify environment
+
+Specifying `environment` only alters the RVI category by using different RVI cutoffs for non-volatile, low, moderate, and high volatility. Environment options and their category cutoffs are in the `calc_vol()` documentation and are discussed in more detail in Meredith et al. (2023) and Donahue et al. (2006).
+
+```{r}
+calc_vol(mol_paths, environment = "soil")
+```
+
+### Return intermediate steps
+
+`calc_vol()` uses a modified version of the SIMPOL.1 method by default which is a group contribution method.  You can have `calc_vol()` return the counts of functional groups and other molecular properties (which is useful for validation) with `return_fx_groups = TRUE`.  See `?get_fx_groups()` for more information about these additional columns.
+
+```{r}
+calc_vol(mol_paths, return_fx_groups = TRUE)
+```
+
+The SIMPOL.1 method calculates $\textrm{log}_{10} P_{\textrm{L},i}^\circ(T)$, which is used by `calc_vol()` to calculate RVI as $\textrm{log}_{10}(PM/RT)$ where $P$ is the estimated vapor pressure for the compound, $M$ is molecular weight of the compound, $R$ is the universal gas constant, and $T$ is temperature (293.14K or 20ºC). To see these intermediate calculations, use `return_calc_steps = TRUE`.
+
+```{r}
+calc_vol(mol_paths, return_calc_steps = TRUE)
+```
+`log_alpha` = $\textrm{log}_{10}(M/RT)$
+
+### Use with SMILES
+
+Finally, all of this can be done using [SMILES](https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system) strings rather than .mol files with `from = "smiles"`.  Backslash, `\` is a valid SMILES character, but isn't a valid character in R and must be "escaped" as `\\`.
+
+```{r}
+## This will error even though the SMILES is correct
+# calc_vol("CC/C=C\C[C@@H]1[C@H](CCC1=O)CC(=O)O", from = "smiles")
+
+# To solve this, escape \C as \\C
+calc_vol("CC/C=C\\C[C@@H]1[C@H](CCC1=O)CC(=O)O", from = "smiles")
+```
+
+### References
+
+Donahue, N.M., Robinson, A.L., Stanier, C.O., Pandis, S.N., 2006. Coupled Partitioning, Dilution, and Chemical Aging of Semivolatile Organics. Environ. Sci. Technol. 40, 2635–2643. DOI: 10.1021/es052297c
+
+Meredith L, Ledford S, Riemer K, Geffre P, Graves K, Honeker L, LeBauer D, Tfaily M, Krechmer J, 2023. Automating methods for estimating metabolite volatility. Frontiers in Microbiology. DOI: 10.3389/fmicb.2023.1267234

--- a/vignettes/volcalc.Rmd
+++ b/vignettes/volcalc.Rmd
@@ -7,14 +7,12 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
-knitr::opts_chunk$set(
-  collapse = TRUE,
-  comment = "#>"
-)
-```
+<!-- generated from volcalc-source.Rmd.source.  Please edit that file! -->
 
-```{r setup}
+
+
+
+```r
 library(volcalc)
 ```
 
@@ -22,38 +20,87 @@ The primary function in `volcalc` is `calc_vol()`.  It accepts either a path to 
 
 ### Basic usage with .mol files
 
-```{r}
+
+```r
 #using built-in example .mol files
 mol_paths <- mol_example()
 mol_paths
+#> [1] "/Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C00031.mol"
+#> [2] "/Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C08491.mol"
+#> [3] "/Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C16181.mol"
+#> [4] "/Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C16286.mol"
+#> [5] "/Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C16521.mol"
 ```
 
 The default output of `calc_vol()` includes a relative volatility index, `rvi` which is equivalent to $\textrm{log}_{10}C^\ast$ (Meredith et al., 2023).  It also includes a RVI category for clean air.
 
-```{r}
+
+```r
 calc_vol(mol_paths)
+#> # A tibble: 5 × 5
+#>   mol_path                                                          formula  name                  rvi category
+#>   <chr>                                                             <chr>    <chr>               <dbl> <fct>   
+#> 1 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C00031.mol C6H12O6  D-Glucose           -2.81 non-vol…
+#> 2 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C08491.mol C12H18O3 (-)-Jasmonic acid    1.84 moderate
+#> 3 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C16181.mol C6H7Cl5O beta-2,3,4,5,6-Pen…  6.98 high    
+#> 4 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C16286.mol C12H22O  Geosmin              4.16 high    
+#> 5 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C16521.mol C5H8     Isoprene             8.84 high
 ```
 
 ### Specify environment
 
 Specifying `environment` only alters the RVI category by using different RVI cutoffs for non-volatile, low, moderate, and high volatility. Environment options and their category cutoffs are in the `calc_vol()` documentation and are discussed in more detail in Meredith et al. (2023) and Donahue et al. (2006).
 
-```{r}
+
+```r
 calc_vol(mol_paths, environment = "soil")
+#> # A tibble: 5 × 5
+#>   mol_path                                                          formula  name                  rvi category
+#>   <chr>                                                             <chr>    <chr>               <dbl> <fct>   
+#> 1 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C00031.mol C6H12O6  D-Glucose           -2.81 non-vol…
+#> 2 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C08491.mol C12H18O3 (-)-Jasmonic acid    1.84 non-vol…
+#> 3 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C16181.mol C6H7Cl5O beta-2,3,4,5,6-Pen…  6.98 moderate
+#> 4 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C16286.mol C12H22O  Geosmin              4.16 low     
+#> 5 /Users/ericscott/Documents/GitHub/volcalc/inst/extdata/C16521.mol C5H8     Isoprene             8.84 high
 ```
 
 ### Return intermediate steps
 
 `calc_vol()` uses a modified version of the SIMPOL.1 method by default which is a group contribution method.  You can have `calc_vol()` return the counts of functional groups and other molecular properties (which is useful for validation) with `return_fx_groups = TRUE`.  See `?get_fx_groups()` for more information about these additional columns.
 
-```{r}
+
+```r
 calc_vol(mol_paths, return_fx_groups = TRUE)
+#> # A tibble: 5 × 53
+#>   mol_path               formula name    rvi category exact_mass carbons carbons_asa rings_aromatic rings_total
+#>   <chr>                  <chr>   <chr> <dbl> <fct>         <dbl>   <int>       <int>          <int>       <int>
+#> 1 /Users/ericscott/Docu… C6H12O6 D-Gl… -2.81 non-vol…      180.        6           0              0           1
+#> 2 /Users/ericscott/Docu… C12H18… (-)-…  1.84 moderate      210.       12           0              0           1
+#> 3 /Users/ericscott/Docu… C6H7Cl… beta…  6.98 high          270.        6           0              0           1
+#> 4 /Users/ericscott/Docu… C12H22O Geos…  4.16 high          182.       12           0              0           2
+#> 5 /Users/ericscott/Docu… C5H8    Isop…  8.84 high           68.1       5           0              0           0
+#> # ℹ 43 more variables: rings_aliphatic <int>, carbon_dbl_bonds_aliphatic <int>, CCCO_aliphatic_ring <int>,
+#> #   hydroxyl_total <int>, hydroxyl_aromatic <int>, hydroxyl_aliphatic <int>, aldehydes <int>, ketones <int>,
+#> #   carbox_acids <int>, ester <int>, ether_total <int>, ether_alkyl <int>, ether_alicyclic <int>,
+#> #   ether_aromatic <int>, nitrate <int>, nitro <int>, amine_primary <int>, amine_secondary <int>,
+#> #   amine_tertiary <int>, amine_aromatic <int>, amide_primary <int>, amide_secondary <int>,
+#> #   amide_tertiary <int>, carbonylperoxynitrate <int>, peroxide <int>, hydroperoxide <int>,
+#> #   carbonylperoxyacid <int>, nitrophenol <int>, nitroester <int>, phosphoric_acids <int>, …
 ```
 
 The SIMPOL.1 method calculates $\textrm{log}_{10} P_{\textrm{L},i}^\circ(T)$, which is used by `calc_vol()` to calculate RVI as $\textrm{log}_{10}(PM/RT)$ where $P$ is the estimated vapor pressure for the compound, $M$ is molecular weight of the compound, $R$ is the universal gas constant, and $T$ is temperature (293.14K or 20ºC). To see these intermediate calculations, use `return_calc_steps = TRUE`.
 
-```{r}
+
+```r
 calc_vol(mol_paths, return_calc_steps = TRUE)
+#> # A tibble: 5 × 8
+#>   mol_path                                      formula name    rvi category molecular_weight log_alpha log10_P
+#>   <chr>                                         <chr>   <chr> <dbl> <fct>               <dbl>     <dbl>   <dbl>
+#> 1 /Users/ericscott/Documents/GitHub/volcalc/in… C6H12O6 D-Gl… -2.81 non-vol…            180.       9.87  -12.7 
+#> 2 /Users/ericscott/Documents/GitHub/volcalc/in… C12H18… (-)-…  1.84 moderate            210.       9.94   -8.10
+#> 3 /Users/ericscott/Documents/GitHub/volcalc/in… C6H7Cl… beta…  6.98 high                272.      10.1    -3.08
+#> 4 /Users/ericscott/Documents/GitHub/volcalc/in… C12H22O Geos…  4.16 high                182.       9.88   -5.72
+#> 5 /Users/ericscott/Documents/GitHub/volcalc/in… C5H8    Isop…  8.84 high                 68.1      9.45   -0.61
 ```
 `log_alpha` = $\textrm{log}_{10}(M/RT)$
 
@@ -61,12 +108,17 @@ calc_vol(mol_paths, return_calc_steps = TRUE)
 
 Finally, all of this can be done using [SMILES](https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system) strings rather than .mol files with `from = "smiles"`.  Backslash, `\` is a valid SMILES character, but isn't a valid character in R and must be "escaped" as `\\`.
 
-```{r}
+
+```r
 ## This will error even though the SMILES is correct
 # calc_vol("CC/C=C\C[C@@H]1[C@H](CCC1=O)CC(=O)O", from = "smiles")
 
 # To solve this, escape \C as \\C
 calc_vol("CC/C=C\\C[C@@H]1[C@H](CCC1=O)CC(=O)O", from = "smiles")
+#> # A tibble: 1 × 5
+#>   smiles                                 formula  name    rvi category
+#>   <chr>                                  <chr>    <chr> <dbl> <fct>   
+#> 1 "CC/C=C\\C[C@@H]1[C@H](CCC1=O)CC(=O)O" C12H18O3 <NA>   1.84 moderate
 ```
 
 ### References


### PR DESCRIPTION
We think the CRAN pre-test is failing because OpenBabel isn't installed on their Debian runner and is making it impossible to install `ChemmineOB`.  This PR moves `ChemmineOB` from Imports to Suggests and does a bunch of other things to make this work:
- Prompts user to install `ChemmineOB` when they first run `get_fx_groups()` (or `calc_vol()`) using `pak`, which, if they are on linux, will also take care of OpenBabel installation (yay!).  So, it's just macOS folks who will have to struggle with that now hopefully.
- Only runs examples if `ChemmineOB` is installed (essentially skipping them on CRAN)
- Precomputes the main `volcalc` vignette also, since `ChemmineOB` is needed to render it.
- Skips all tests of `get_fx_groups()` and `calc_vol()` if `ChemmineOB` isn't installed (Question: would it be better to `skip_on_cran()` instead?).  I think this means that _no_ tests are run on CRAN because the KEGG tests are also skipped, and they might complain about that. Ugh!

I'm now questioning whether this will even work.  I think CRAN tries to install Suggests dependencies as well and I'm not sure what happens if one of those errors.

We should run `rhub::check_on_debian()` and/or `rhub::check_for_cran()` on this branch before merging and re-submitting.