### PR TITLE
Remove `KEGGREST` dependency

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
+          - {os: macos-13,   r: 'release'} #TODO change back to macos-latest some day when ChemmineOB works on M1
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,8 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-13,   r: 'release'} #TODO change back to macos-latest some day when ChemmineOB works on M1
-          - {os: windows-latest, r: 'release'}
+          - {os: macos-13,        r: 'release'} #TODO remove some day when ChemmineOB works on Apple silicon
+          - {os: macos-latest,    r: 'release'}
+          - {os: windows-latest,  r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,7 +39,7 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
       - name: macOS openbabel
-        if: matrix.config.os == 'macos-latest'
+        if: contains(matrix.config.os, 'macos')
         run: |
           brew install open-babel
       - name: ubuntu openbabel

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get install libeigen3-dev
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, bioc::ChemmineOB
+          extra-packages: any::rcmdcheck
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get install libeigen3-dev
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, bioc::ChemmineOB
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
     fs,
     glue,
     httr2,
-    KEGGREST,
     magrittr,
     purrr,
     rlang,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ biocViews:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # volcalc (development version)
 
 * adds a `validate = TRUE` option to `calc_vol()` and `get_fx_groups()` that returns `NA`s when there are suspected errors in parsing SMILES or .mol files. This is unfortunately not available on Windows due to differences in the windows version of `ChemmineOB`
+* `KEGGREST` is no longer a dependency of `volcalc` (previously used in `get_mol_kegg()`)
 
 # volcalc 2.1.2
 

--- a/R/get_mol_kegg.R
+++ b/R/get_mol_kegg.R
@@ -110,7 +110,8 @@ get_compounds_kegg <- function(pathway){
   
 }
 
-#' Get mol files for a single API request of up to 10 IDs
+#' Get and wrangle mol files for a single API request of up to 10 IDs
+#' @noRd
 .dl_mol_kegg <- function(ids) {
   if (length(ids) > 10) {
     stop("Provide 10 or fewer IDs at a time")
@@ -147,6 +148,8 @@ get_compounds_kegg <- function(pathway){
   paste0(names, "\n\n\n", mols)
 }
 
+#' Split vector into list elements of max length
+#' @noRd
 split_to_list <- function(x, max_len = 10) {
   
   if(length(x) > max_len) {
@@ -159,8 +162,8 @@ split_to_list <- function(x, max_len = 10) {
   
 }
 
-#' Download compound_ids by splitting into groups of 10 and calling .dl_mol_kegg
-#' 
+#' Get mol files for compound_ids by splitting into groups of 10 and calling .dl_mol_kegg
+#' @noRd
 dl_mol_kegg <- function(compound_ids) {
   #balances compound_ids into groups of less than 10 to meet API guidelines
   compound_id_list <- split_to_list(compound_ids, max_len = 10)

--- a/R/get_mol_kegg.R
+++ b/R/get_mol_kegg.R
@@ -116,14 +116,14 @@ get_compounds_kegg <- function(pathway){
   if (length(ids) > 10) {
     stop("Provide 10 or fewer IDs at a time")
   }
-  # get first suggested name
   req_names <- 
     httr2::request("https://rest.kegg.jp/get") %>% 
     httr2::req_url_path_append(paste(ids, collapse = "+"))
-  
+
   resp_names <- httr2::req_perform(req_names) %>% 
     httr2::resp_body_string()
   
+  # There's a lot of stuff in the response, but I only care about the compound name
   names <- resp_names %>%
     stringr::str_extract_all("(?<=NAME).+(?=\\n)") %>%
     unlist() %>% 
@@ -131,20 +131,20 @@ get_compounds_kegg <- function(pathway){
     stringr::str_remove(";")
   
   # get mol file
-  
   req_mols <- req_names %>% 
     httr2::req_url_path_append("mol")
   
   resp_mols <- httr2::req_perform(req_mols) %>% 
     httr2::resp_body_string()
   
+  # wrangle into valid mol files
   mols <- resp_mols %>% 
     stringr::str_split("(?<=\\${4})", n = length(ids)) %>%
     unlist() %>% 
     stringr::str_trim(side = "left") %>% 
     gsub(">.*", "", .) #for some reason this pattern doesn't work with str_remove()
   
-  #add title row
+  #add compound name in correct place
   paste0(names, "\n\n\n", mols)
 }
 

--- a/R/get_mol_kegg.R
+++ b/R/get_mol_kegg.R
@@ -13,13 +13,13 @@ utils::globalVariables(".data")
 #' @param force Logical; by default (`FALSE`), .mol files will not be downloaded
 #'   if they are found in `dir`. Set this to `TRUE` to download and overwrite
 #'   existing files.
-#'   
+#'
 #' @note For additional functionality for interacting with KEGG, try the
 #'   `KEGGREST` package, which this function was inspired by.
-#'   
+#'
 #' @returns A tibble with the columns `compound_ids`, `pathway_ids` (if used),
 #'   and `mol_paths` (paths to downloaded .mol files).
-#'   
+#'
 #' @export
 #'
 #' @examples
@@ -27,14 +27,15 @@ utils::globalVariables(".data")
 #' get_mol_kegg(compound_ids = c("C16181", "C06074"), dir = tempdir())
 #' get_mol_kegg(pathway_ids = "map00253", dir = tempdir())
 #' }
-get_mol_kegg <- function(compound_ids, pathway_ids, dir, force = FALSE){
-  
-  if(missing(dir)) stop("`dir` is required")
-  if ((missing(compound_ids) & missing(pathway_ids)) |
-      !missing(compound_ids) & !missing(pathway_ids)) {
+get_mol_kegg <- function(compound_ids, pathway_ids, dir, force = FALSE) {
+  if (missing(dir)) stop("`dir` is required")
+  if (
+    (missing(compound_ids) & missing(pathway_ids)) |
+      !missing(compound_ids) & !missing(pathway_ids)
+  ) {
     stop("One of `compound_ids` or `pathway_ids` are required")
   }
-  
+
   #if compounds are provided
   if (!missing(compound_ids)) {
     if (!all(stringr::str_detect(compound_ids, "^[C][:digit:]{5}$"))) {
@@ -42,7 +43,7 @@ get_mol_kegg <- function(compound_ids, pathway_ids, dir, force = FALSE){
     }
     fs::dir_create(dir)
     out_tbl <-
-      tibble::tibble(compound_id = compound_ids) %>% 
+      tibble::tibble(compound_id = compound_ids) %>%
       dplyr::mutate(mol_path = fs::path(dir, .data$compound_id, ext = "mol"))
   }
   # if pathways are provided
@@ -53,28 +54,38 @@ get_mol_kegg <- function(compound_ids, pathway_ids, dir, force = FALSE){
     fs::dir_create(dir, pathway_ids)
     compound_ids_list <- lapply(pathway_ids, get_compounds_kegg)
     names(compound_ids_list) <- pathway_ids
-    out_tbl <- 
-      tibble::enframe(compound_ids_list, name = "pathway_id", value = "compound_id") %>% 
-      tidyr::unnest(tidyselect::everything()) %>% 
-      dplyr::mutate(mol_path = fs::path(dir, .data$pathway_id, .data$compound_id, ext = "mol"))
+    out_tbl <-
+      tibble::enframe(
+        compound_ids_list,
+        name = "pathway_id",
+        value = "compound_id"
+      ) %>%
+      tidyr::unnest(tidyselect::everything()) %>%
+      dplyr::mutate(
+        mol_path = fs::path(
+          dir,
+          .data$pathway_id,
+          .data$compound_id,
+          ext = "mol"
+        )
+      )
   }
-  
-  if(isFALSE(force)) {
+
+  if (isFALSE(force)) {
     to_dl <- out_tbl$compound_id[!fs::file_exists(out_tbl$mol_path)]
     out_paths <- out_tbl$mol_path[!fs::file_exists(out_tbl$mol_path)]
   } else {
     to_dl <- out_tbl$compound_id
     out_paths <- out_tbl$mol_path
   }
-  
+
   if (length(to_dl) == 0) {
     #if nothing to download, return early
     return(out_tbl)
   } else {
-    
     # Download mols
     mols <- dl_mol_kegg(to_dl)
-    
+
     # write mol files
     .write_mol <- function(mol_clean, file_path) {
       utils::write.table(
@@ -85,9 +96,9 @@ get_mol_kegg <- function(compound_ids, pathway_ids, dir, force = FALSE){
         quote = FALSE
       )
     }
-    
+
     mapply(.write_mol, mol_clean = mols, file_path = out_paths)
-    
+
     return(out_tbl)
   }
 }
@@ -97,21 +108,22 @@ get_mol_kegg <- function(compound_ids, pathway_ids, dir, force = FALSE){
 #'
 #' @param pathway string that is a KEGG identifier for a molecular pathway
 #' @noRd
-get_compounds_kegg <- function(pathway){
-  
-  resp <- 
-    httr2::request("https://rest.kegg.jp/")  %>%  
-    httr2::req_url_path("link/cpd/") %>%  
-    httr2::req_url_path_append(pathway) %>% 
-    httr2::req_retry(max_tries = 3) %>% 
+get_compounds_kegg <- function(pathway) {
+  resp <-
+    httr2::request("https://rest.kegg.jp/") %>%
+    httr2::req_user_agent(
+      "volcalc (https://github.com/Meredith-Lab/volcalc/)"
+    ) %>%
+    httr2::req_url_path("link/cpd/") %>%
+    httr2::req_url_path_append(pathway) %>%
+    httr2::req_retry(max_tries = 3) %>%
     httr2::req_perform()
-  
-  out <- resp %>% 
-    httr2::resp_body_string() %>%  
-    stringr::str_split_1("\n") %>%  
+
+  out <- resp %>%
+    httr2::resp_body_string() %>%
+    stringr::str_split_1("\n") %>%
     stringr::str_extract("(?<=cpd:).*")
   out[!is.na(out)]
-  
 }
 
 #' Get and wrangle mol files for a single API request of up to 10 IDs
@@ -120,36 +132,39 @@ get_compounds_kegg <- function(pathway){
   if (length(ids) > 10) {
     stop("Provide 10 or fewer IDs at a time")
   }
-  req_names <- 
-    httr2::request("https://rest.kegg.jp/get") %>% 
-    httr2::req_url_path_append(paste(ids, collapse = "+")) %>% 
+  req_names <-
+    httr2::request("https://rest.kegg.jp/get") %>%
+    httr2::req_user_agent(
+      "volcalc (https://github.com/Meredith-Lab/volcalc/)"
+    ) %>%
+    httr2::req_url_path_append(paste(ids, collapse = "+")) %>%
     httr2::req_retry(max_tries = 3)
 
-  resp_names <- httr2::req_perform(req_names) %>% 
+  resp_names <- httr2::req_perform(req_names) %>%
     httr2::resp_body_string()
-  
+
   # There's a lot of stuff in the response, but I only care about the compound name
   names <- resp_names %>%
     stringr::str_extract_all("(?<=NAME).+(?=\\n)") %>%
-    unlist() %>% 
-    stringr::str_trim() %>% 
+    unlist() %>%
+    stringr::str_trim() %>%
     stringr::str_remove(";")
-  
+
   # get mol file
-  req_mols <- req_names %>% 
+  req_mols <- req_names %>%
     httr2::req_url_path_append("mol")
-  
-  resp_mols <- httr2::req_perform(req_mols) %>% 
+
+  resp_mols <- httr2::req_perform(req_mols) %>%
     httr2::resp_body_string()
-  
+
   # wrangle into valid mol files
-  mols <- resp_mols %>% 
+  mols <- resp_mols %>%
     stringr::str_split("(?<=\\${4})", n = length(ids)) %>%
-    unlist() %>% 
+    unlist() %>%
     stringr::str_trim(side = "left")
-  mols <- 
+  mols <-
     gsub(">.*", "", mols) #for some reason this pattern doesn't work with str_remove()
-  
+
   #add compound name in correct place
   paste0(names, "\n\n\n", mols)
 }
@@ -157,15 +172,13 @@ get_compounds_kegg <- function(pathway){
 #' Split vector into list elements of max length
 #' @noRd
 split_to_list <- function(x, max_len = 10) {
-  
-  if(length(x) > max_len) {
+  if (length(x) > max_len) {
     n_groups <- ceiling(length(x) / max_len)
     split(x, f = cut(seq_along(x), breaks = n_groups)) %>%
       purrr::set_names(NULL)
   } else {
     list(x)
   }
-  
 }
 
 #' Get mol files for compound_ids by splitting into groups of 10 and calling .dl_mol_kegg
@@ -173,8 +186,8 @@ split_to_list <- function(x, max_len = 10) {
 dl_mol_kegg <- function(compound_ids) {
   #balances compound_ids into groups of less than 10 to meet API guidelines
   compound_id_list <- split_to_list(compound_ids, max_len = 10)
-  
+
   #maps over list, but returns it to a single character vector to simplify wrangling code
-  purrr::map(compound_id_list, .dl_mol_kegg) %>% 
+  purrr::map(compound_id_list, .dl_mol_kegg, .progress = "Downloading") %>%
     purrr::list_c()
 }

--- a/R/get_mol_kegg.R
+++ b/R/get_mol_kegg.R
@@ -122,7 +122,8 @@ get_compounds_kegg <- function(pathway){
   }
   req_names <- 
     httr2::request("https://rest.kegg.jp/get") %>% 
-    httr2::req_url_path_append(paste(ids, collapse = "+"))
+    httr2::req_url_path_append(paste(ids, collapse = "+")) %>% 
+    httr2::req_retry(max_tries = 3)
 
   resp_names <- httr2::req_perform(req_names) %>% 
     httr2::resp_body_string()

--- a/R/get_mol_kegg.R
+++ b/R/get_mol_kegg.R
@@ -14,8 +14,12 @@ utils::globalVariables(".data")
 #'   if they are found in `dir`. Set this to `TRUE` to download and overwrite
 #'   existing files.
 #'   
+#' @note For additional functionality for interacting with KEGG, try the
+#'   `KEGGREST` package, which this function was inspired by.
+#'   
 #' @returns A tibble with the columns `compound_ids`, `pathway_ids` (if used),
 #'   and `mol_paths` (paths to downloaded .mol files).
+#'   
 #' @export
 #'
 #' @examples

--- a/R/get_mol_kegg.R
+++ b/R/get_mol_kegg.R
@@ -141,8 +141,9 @@ get_compounds_kegg <- function(pathway){
   mols <- resp_mols %>% 
     stringr::str_split("(?<=\\${4})", n = length(ids)) %>%
     unlist() %>% 
-    stringr::str_trim(side = "left") %>% 
-    gsub(">.*", "", .) #for some reason this pattern doesn't work with str_remove()
+    stringr::str_trim(side = "left")
+  mols <- 
+    gsub(">.*", "", mols) #for some reason this pattern doesn't work with str_remove()
   
   #add compound name in correct place
   paste0(names, "\n\n\n", mols)

--- a/R/get_mol_kegg.R
+++ b/R/get_mol_kegg.R
@@ -176,6 +176,5 @@ dl_mol_kegg <- function(compound_ids) {
   
   #maps over list, but returns it to a single character vector to simplify wrangling code
   purrr::map(compound_id_list, .dl_mol_kegg) %>% 
-    purrr::list_c() %>% 
-    glue::glue_collapse()
+    purrr::list_c()
 }

--- a/R/get_mol_kegg.R
+++ b/R/get_mol_kegg.R
@@ -47,7 +47,7 @@ get_mol_kegg <- function(compound_ids, pathway_ids, dir, force = FALSE){
       stop("Some pathway_ids are not in the correct KEGG format")
     }
     fs::dir_create(dir, pathway_ids)
-    compound_ids_list <- lapply(pathway_ids, keggGetCompounds)
+    compound_ids_list <- lapply(pathway_ids, get_compounds_kegg)
     names(compound_ids_list) <- pathway_ids
     out_tbl <- 
       tibble::enframe(compound_ids_list, name = "pathway_id", value = "compound_id") %>% 
@@ -91,12 +91,9 @@ get_mol_kegg <- function(compound_ids, pathway_ids, dir, force = FALSE){
 
 #' Get list of KEGG compound IDs for given KEGG pathway
 #'
-#' This is a temporary helper function until this function is improved and
-#' pushed into KEGGREST package
-#'
 #' @param pathway string that is a KEGG identifier for a molecular pathway
 #' @noRd
-keggGetCompounds <- function(pathway){
+get_compounds_kegg <- function(pathway){
   
   resp <- 
     httr2::request("https://rest.kegg.jp/")  %>%  

--- a/README.Rmd
+++ b/README.Rmd
@@ -77,6 +77,9 @@ For windows, `OpenBabel` is included in the `ChemmineOB` binary and does not nee
 
 For other installation options see the [OpenBabel documentation](https://open-babel.readthedocs.io/en/latest/Installation/install.html) and `ChemmineOB` [install guide](https://github.com/girke-lab/ChemmineOB/blob/master/INSTALL)
 
+> [!NOTE]  
+> As of Dec 2024, `ChemmineOB` may fail to build on macs with Apple silicon (https://github.com/girke-lab/ChemmineOB/issues/35) causing installation failture for `volcalc`.
+
 ## Basic Usage
 
 This is a basic example which shows you how to get an estimated relative volatility index (`rvi`) for two example compounds *beta-2,3,4,5,6-Pentachlorocyclohexanol*, and *Succinate*.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,11 @@ strings as input, and supports downloading .mol files directly from
 
 ## Installation
 
-<!--
 Install from CRAN with
 
 ``` r
 install.packages("volcalc")
 ```
--->
 
 You can install the development version of `volcalc` from GitHub with
 
@@ -96,6 +94,11 @@ documentation](https://open-babel.readthedocs.io/en/latest/Installation/install.
 and `ChemmineOB` [install
 guide](https://github.com/girke-lab/ChemmineOB/blob/master/INSTALL)
 
+> \[!NOTE\]  
+> As of Dec 2024, `ChemmineOB` may fail to build on macs with Apple
+> silicon (<https://github.com/girke-lab/ChemmineOB/issues/35>) causing
+> installation failture for `volcalc`.
+
 ## Basic Usage
 
 This is a basic example which shows you how to get an estimated relative
@@ -118,7 +121,7 @@ calc_vol(files$mol_path)
 #>   mol_path                                          formula name    rvi category
 #>   <chr>                                             <chr>   <chr> <dbl> <fct>   
 #> 1 /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T… C6H7Cl… beta…  6.98 high    
-#> 2 /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T… C4H6O4  Succ…  2.57 high
+#> 2 /var/folders/wr/by_lst2d2fngf67mknmgf4340000gn/T… C6H7Cl… beta…  6.98 high
 
 #alternatively, supply a SMILES representation
 calc_vol(c("C1(C(C(C(C(C1Cl)Cl)Cl)Cl)Cl)O",  "C(CC(=O)O)C(=O)O"), from = "smiles")

--- a/man/get_mol_kegg.Rd
+++ b/man/get_mol_kegg.Rd
@@ -28,6 +28,10 @@ and \code{mol_paths} (paths to downloaded .mol files).
 Downloads mol files corresponding to individual compounds or compounds in a
 pathway from KEGG.
 }
+\note{
+For additional functionality for interacting with KEGG, try the
+\code{KEGGREST} package, which this function was inspired by.
+}
 \examples{
 \dontrun{
 get_mol_kegg(compound_ids = c("C16181", "C06074"), dir = tempdir())

--- a/tests/testthat/test-get_mol_kegg.R
+++ b/tests/testthat/test-get_mol_kegg.R
@@ -110,3 +110,14 @@ test_that("works with pathway modules", {
   expect_true(all(file.exists(out$mol_path)))
 })
 
+test_that("one compound per mol", {
+  skip_on_cran()
+  skip_if_offline()
+  
+  dir <- withr::local_tempdir()
+  mols <- get_mol_kegg(c("C16181", "C00042"), dir = dir)
+  mol1 <- readLines(mols$mol_path[1])
+  mol2 <- readLines(mols$mol_path[2])
+  expect_equal(sum(stringr::str_detect(mol1, "END")), 1)
+  expect_equal(sum(stringr::str_detect(mol2, "END")), 1)
+})

--- a/vignettes/volcalc.Rmd
+++ b/vignettes/volcalc.Rmd
@@ -12,7 +12,6 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
-library(ChemmineOB)
 ```
 
 ```{r setup}

--- a/vignettes/volcalc.Rmd
+++ b/vignettes/volcalc.Rmd
@@ -12,6 +12,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+library(ChemmineOB)
 ```
 
 ```{r setup}


### PR DESCRIPTION
Closes #108 by accessing KEGG API directly with `httr2` (already a dependency) for getting mol files.